### PR TITLE
Pygments style should default to material

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,10 +75,6 @@ language = None
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = []
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
-
-
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
Currently the Sphinx style is used, which renders the commands in a green/yellow box. This deviates from the Material theme