### PR TITLE
Fix goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,25 +10,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Unit Tests
-        uses: cedrickring/golang-action@1.5.2
-        env:
-          GO111MODULE: "on"
-        with:
-          args: make install && make test_unit_codecov
-      - name: Push CodeCov
-        uses: codecov/codecov-action@v1
-        with:
-          file: coverage.txt
-          flags: unittests
-          fail_ci_if_error: true
-      - name: Lint
-        uses: cedrickring/golang-action@1.5.2
-        env:
-          GO111MODULE: "on"
-        with:
-          args: make install && make lint
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
Signed-off-by: Yuvraj <evalsocket@gmail.com>

# TL;DR
Because of lint and test git is dirty in ci workflow. Remove lint and unit test from release. 
Lint and unit test will execute in each PR and run in release separately 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
