### PR TITLE
 Flytectl get started added for running example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,20 @@ Generating docs locally can be accomplished by running make gendocs from within 
 $ brew tap flyteorg/homebrew-tap
 $ brew install flytectl
 ```
+## Get Started 
 
+### Create a sandbox cluster 
+```bash
+$ docker run --rm --privileged -p 30081:30081 -p 30082:30082 -p 30084:30084 ghcr.io/flyteorg/flyte-sandbox
+```
+
+### Register your first workflow
+
+```bash
+# Run Core workflows 
+$ flytectl register files https://github.com/flyteorg/flytesnacks/releases/download/v0.2.89/flytesnacks-core.tgz -d development  -p flytesnacks --archive  
+# You can find all example at flytesnacks release page  https://github.com/flyteorg/flytesnacks/releases/tag/v0.2.89 
+```
 ## Contributing
 
 [Contribution guidelines for this project](docs/CONTRIBUTING.md)


### PR DESCRIPTION
# TL;DR
- Added Get started guide for registering first workflow 

For testing examples are available at https://github.com/flyteorg/flytesnacks/releases/tag/v0.2.89 

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
https://github.com/flyteorg/flytesnacks/pull/166
https://github.com/flyteorg/flyte/pull/942
