### PR TITLE
Removed the generated code in flag files which is not used

### DIFF
--- a/cmd/config/config_flags.go
+++ b/cmd/config/config_flags.go
@@ -4,38 +4,10 @@
 package config
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (Config) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (Config) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in Config and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/config/subcommand/taskresourceattribute/attrdeleteconfig_flags.go
+++ b/cmd/config/subcommand/taskresourceattribute/attrdeleteconfig_flags.go
@@ -4,38 +4,10 @@
 package taskresourceattribute
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (AttrDeleteConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (AttrDeleteConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in AttrDeleteConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/config/subcommand/taskresourceattribute/attrfetchconfig_flags.go
+++ b/cmd/config/subcommand/taskresourceattribute/attrfetchconfig_flags.go
@@ -4,38 +4,10 @@
 package taskresourceattribute
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (AttrFetchConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (AttrFetchConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in AttrFetchConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/config/subcommand/taskresourceattribute/attrupdateconfig_flags.go
+++ b/cmd/config/subcommand/taskresourceattribute/attrupdateconfig_flags.go
@@ -4,38 +4,10 @@
 package taskresourceattribute
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (AttrUpdateConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (AttrUpdateConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in AttrUpdateConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/config/subcommand/workflow/config_flags.go
+++ b/cmd/config/subcommand/workflow/config_flags.go
@@ -4,38 +4,10 @@
 package workflow
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (Config) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (Config) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in Config and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/create/executionconfig_flags.go
+++ b/cmd/create/executionconfig_flags.go
@@ -4,38 +4,10 @@
 package create
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (ExecutionConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (ExecutionConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in ExecutionConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/create/projectconfig_flags.go
+++ b/cmd/create/projectconfig_flags.go
@@ -4,47 +4,10 @@
 package create
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (ProjectConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (ProjectConfig) mustJsonMarshal(v interface{}) string {
-	raw, err := json.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
-
-func (ProjectConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in ProjectConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/get/launchplanconfig_flags.go
+++ b/cmd/get/launchplanconfig_flags.go
@@ -4,38 +4,10 @@
 package get
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (LaunchPlanConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (LaunchPlanConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in LaunchPlanConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/get/taskconfig_flags.go
+++ b/cmd/get/taskconfig_flags.go
@@ -4,38 +4,10 @@
 package get
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (TaskConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (TaskConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in TaskConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/update/namedentityconfig_flags.go
+++ b/cmd/update/namedentityconfig_flags.go
@@ -4,38 +4,10 @@
 package update
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (NamedEntityConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (NamedEntityConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in NamedEntityConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.

--- a/cmd/update/projectconfig_flags.go
+++ b/cmd/update/projectconfig_flags.go
@@ -4,38 +4,10 @@
 package update
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"fmt"
 
 	"github.com/spf13/pflag"
 )
-
-// If v is a pointer, it will get its element value or the zero value of the element type.
-// If v is not a pointer, it will return it as is.
-func (ProjectConfig) elemValueOrNil(v interface{}) interface{} {
-	if t := reflect.TypeOf(v); t.Kind() == reflect.Ptr {
-		if reflect.ValueOf(v).IsNil() {
-			return reflect.Zero(t.Elem()).Interface()
-		} else {
-			return reflect.ValueOf(v).Interface()
-		}
-	} else if v == nil {
-		return reflect.Zero(t).Interface()
-	}
-
-	return v
-}
-
-func (ProjectConfig) mustMarshalJSON(v json.Marshaler) string {
-	raw, err := v.MarshalJSON()
-	if err != nil {
-		panic(err)
-	}
-
-	return string(raw)
-}
 
 // GetPFlagSet will return strongly types pflags for all fields in ProjectConfig and its nested types. The format of the
 // flags is json-name.json-sub-name... etc.


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

The generated code function of `elemValueOrNil` and `mustMarshalJSON` are not used in flytectl 
And also the corresponding generated tests for these files don't cover these functions and ultimately reducing the coverage .

Since we have added many flags for the commands , this is overall reducing the UT coverage of the entire repo.

Need to understand more details on when this code will be utilized and if there is flag to not generate it.
This particular line is generating this code 

https://github.com/flyteorg/flytestdlib/blob/99f4b2005d747fb9b4807adfa3e7c27375a5fd35/cli/pflags/api/generator.go#L185

Increases the code coverage by  +5.58%


## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
