### PR TITLE
Added error data and abort data in get execution output

### DIFF
--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -53,6 +53,8 @@ var executionColumns = []printer.Column{
 	{Header: "Phase", JSONPath: "$.closure.phase"},
 	{Header: "Started", JSONPath: "$.closure.startedAt"},
 	{Header: "Elapsed Time", JSONPath: "$.closure.duration"},
+	{Header: "Abort data", JSONPath: "$.closure.abortMetadata[\"cause\"]"},
+	{Header: "Error data", JSONPath: "$.closure.error[\"message\"]"},
 }
 
 func ExecutionToProtoMessages(l []*admin.Execution) []proto.Message {


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Sample get execution ooutput.

```
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| NAME (79)            | LAUNCH PLAN NAME                          | TYPE        | PHASE     | STARTED                     | ELAPSED TIME   | ABORT DATA                                        | ERROR DATA                                                                                                      |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| f1ac227769dfc48c481f | core.flyte_basics.lp.child_workflow       | LAUNCH_PLAN | FAILED    | 2021-05-25T10:38:00.867112Z | 30.177727s     |                                                   | containers with unready status: [furvf51a-n0-0]|Error                                                           |
|                      |                                           |             |           |                             |                |                                                   | response from daemon: Minimum memory limit allowed is                                                           |
|                      |                                           |             |           |                             |                |                                                   | 6MB                                                                                                             |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| f6beffe2d562f463da23 | core.type_system.custom_objects.add       | TASK        | SUCCEEDED | 2021-05-28T14:13:10.678088Z | 7.685044s      |                                                   |                                                                                                                 |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| ffaz4xni             | morning_greeting                          | LAUNCH_PLAN | ABORTED   | 2021-05-25T10:38:01.616057Z | 29.253096s     | cascading abort as parent execution id            |                                                                                                                 |
|                      |                                           |             |           |                             |                | [f1ac227769dfc48c481f] aborted, reason [Some node |                                                                                                                 |
|                      |                                           |             |           |                             |                | execution failed, auto-abort.]                    |                                                                                                                 |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| fto1di2q             | morning_greeting                          | LAUNCH_PLAN | FAILED    | 2021-05-25T10:38:01.403746Z | 29.892845s     |                                                   | Workflow[flytectldemo:development:core.flyte_basics.lp.go_greet]                                                |
|                      |                                           |             |           |                             |                |                                                   | failed. RuntimeExecutionError: max number of system                                                             |
|                      |                                           |             |           |                             |                |                                                   | retry attempts [11/10] exhausted. Last known status                                                             |
|                      |                                           |             |           |                             |                |                                                   | message:                                                                                                        |
|                      |                                           |             |           |                             |                |                                                   | Workflow[flytectldemo:development:core.flyte_basics.lp.go_greet]                                                |
|                      |                                           |             |           |                             |                |                                                   | failed. CausedByError: Failed to propagate Abort for                                                            |
|                      |                                           |             |           |                             |                |                                                   | workflow. Error: 0: failed to record task event, as                                                             |
|                      |                                           |             |           |                             |                |                                                   | it already exists in terminal state. Event state:                                                               |
|                      |                                           |             |           |                             |                |                                                   | ABORTED: EventAlreadyInTerminalStateError: conflicting                                                          |
|                      |                                           |             |           |                             |                |                                                   | events; destination: ABORTED, caused by [rpc error:                                                             |
|                      |                                           |             |           |                             |                |                                                   | code = FailedPrecondition desc = invalid phase change                                                           |
|                      |                                           |             |           |                             |                |                                                   | from FAILED to ABORTED for task execution                                                                       |
|                      |                                           |             |           |                             |                |                                                   | {resource_type:TASK project:"flytectldemo"                                                                      |
|                      |                                           |             |           |                             |                |                                                   | domain:"development" name:"core.flyte_basics.lp.greet"                                                          |
|                      |                                           |             |           |                             |                |                                                   | version:"v1" node_id:"n0"                                                                                       |
|                      |                                           |             |           |                             |                |                                                   | execution_id:<project:"flytectldemo" domain:"development"                                                       |
|                      |                                           |             |           |                             |                |                                                   | name:"fto1di2q" > 0 {} [] 0}]                                                                                   |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- ----------------------------------------------------------------------------------------------------------------- 
| f1ojzhsi             | morning_greeting                          | LAUNCH_PLAN | FAILED    | 2021-05-25T10:38:02.333829Z | 28.244732s     | cascading abort as parent execution id            |                                                                                                                 |
|                      |                                           |             |           |                             |                | [f1ac227769dfc48c481f] aborted, reason [Some node |                                                                                                                 |
|                      |                                           |             |           |                             |                | execution failed, auto-abort.]                    |                                                                                                                 |
 ---------------------- ------------------------------------------- ------------- ----------- ----------------------------- ---------------- --------------------------------------------------- --------------------------------------------------------------------------------------------------------
```

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
