### PR TITLE
Updated version of flyteidl (supports enum type) and removed the pinned version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
-	github.com/flyteorg/flyteidl v0.18.51
+	github.com/flyteorg/flyteidl v0.19.2
 	github.com/flyteorg/flytestdlib v0.3.21
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.3
@@ -29,4 +29,3 @@ require (
 	sigs.k8s.io/yaml v1.2.0
 )
 
-replace github.com/flyteorg/flyteidl => github.com/flyteorg/flyteidl v0.18.51-0.20210602050605-9ebebd25056e

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/flyteorg/flyteidl v0.18.51-0.20210602050605-9ebebd25056e h1:J3Uaju9mBrJhrU4kiv3ozpZNkDdjDepkn0X6ueB8iag=
 github.com/flyteorg/flyteidl v0.18.51-0.20210602050605-9ebebd25056e/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.19.2 h1:jXuRrLJEzSo33N9pw7bMEd6mRYSL7LCz/vnazz5XcOg=
+github.com/flyteorg/flyteidl v0.19.2/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.21 h1:AF+y6wI64DNfoi4WtZU/v18Cfwksg32fijy7PZJ8d+I=
 github.com/flyteorg/flytestdlib v0.3.21/go.mod h1:1XG0DwYTUm34Yrffm1Qy9Tdr/pWQypEqTq5dUxw3/cM=


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Flytectl was pinned to an old version of flyteidl. fixed that and updated the version that supports Enum

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
https://docs.google.com/document/d/1rf0hMKbPebJ7jGYpsTDAbJ4ka58KIKD7EgWAEBIH06Q/edit#

## Tracking Issue
https://github.com/flyteorg/flyte/issues/590

## Follow-up issue
_NA_

