### PR TITLE
Removed parent flags which are not required as of now

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,8 +47,6 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.flyte/config.yaml)")
 
-	configAccessor.InitializePflags(rootCmd.PersistentFlags())
-
 	// Due to https://github.com/flyteorg/flyte/issues/341, project flag will have to be specified as
 	// --root.project, this adds a convenience on top to allow --project to be used
 	rootCmd.PersistentFlags().StringVarP(&(config.GetConfig().Project), "project", "p", "", "Specifies the Flyte project.")

--- a/docs/source/gen/flytectl.rst
+++ b/docs/source/gen/flytectl.rst
@@ -16,45 +16,11 @@ Options
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-  -h, --help                                       help for flytectl
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -h, --help             help for flytectl
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_config.rst
+++ b/docs/source/gen/flytectl_config.rst
@@ -25,44 +25,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_config_discover.rst
+++ b/docs/source/gen/flytectl_config_discover.rst
@@ -27,46 +27,12 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --file stringArray                           Passes the config file to load.
-                                                   If empty, it'll first search for the config file path then, if found, will load config from there.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string      config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string      Specifies the Flyte project's domain.
+      --file stringArray   Passes the config file to load.
+                           If empty, it'll first search for the config file path then, if found, will load config from there.
+  -o, --output string      Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string     Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_config_validate.rst
+++ b/docs/source/gen/flytectl_config_validate.rst
@@ -29,46 +29,12 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --file stringArray                           Passes the config file to load.
-                                                   If empty, it'll first search for the config file path then, if found, will load config from there.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string      config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string      Specifies the Flyte project's domain.
+      --file stringArray   Passes the config file to load.
+                           If empty, it'll first search for the config file path then, if found, will load config from there.
+  -o, --output string      Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string     Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_create.rst
+++ b/docs/source/gen/flytectl_create.rst
@@ -28,44 +28,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -146,44 +146,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_create_project.rst
+++ b/docs/source/gen/flytectl_create_project.rst
@@ -52,44 +52,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete.rst
+++ b/docs/source/gen/flytectl_delete.rst
@@ -28,44 +28,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_delete_cluster-resource-attribute.rst
@@ -64,44 +64,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_delete_execution-cluster-label.rst
@@ -62,44 +62,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_delete_execution-queue-attribute.rst
@@ -66,44 +66,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_execution.rst
+++ b/docs/source/gen/flytectl_delete_execution.rst
@@ -71,44 +71,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_plugin-override.rst
+++ b/docs/source/gen/flytectl_delete_plugin-override.rst
@@ -67,44 +67,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_delete_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_delete_task-resource-attribute.rst
@@ -67,44 +67,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get.rst
+++ b/docs/source/gen/flytectl_get.rst
@@ -28,44 +28,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_get_cluster-resource-attribute.rst
@@ -73,44 +73,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_get_execution-cluster-label.rst
@@ -71,44 +71,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_get_execution-queue-attribute.rst
@@ -75,44 +75,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_execution.rst
+++ b/docs/source/gen/flytectl_get_execution.rst
@@ -68,44 +68,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_launchplan.rst
+++ b/docs/source/gen/flytectl_get_launchplan.rst
@@ -113,44 +113,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_plugin-override.rst
+++ b/docs/source/gen/flytectl_get_plugin-override.rst
@@ -95,44 +95,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_project.rst
+++ b/docs/source/gen/flytectl_get_project.rst
@@ -66,44 +66,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_get_task-resource-attribute.rst
@@ -77,44 +77,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_task.rst
+++ b/docs/source/gen/flytectl_get_task.rst
@@ -109,44 +109,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_get_workflow.rst
+++ b/docs/source/gen/flytectl_get_workflow.rst
@@ -87,7 +87,7 @@ Options
       --filter.asc                     Specifies the sorting order. By default flytectl sort result in descending order
       --filter.field-selector string   Specifies the Field selector
       --filter.limit int32             Specifies the limit (default 100)
-      --filter.sort-by string          Specifies which field to sort results 
+      --filter.sort-by string          Specifies which field to sort results  (default "created_at")
   -h, --help                           help for workflow
       --latest                          flag to indicate to fetch the latest version,  version flag will be ignored in this case
       --version string                 version of the workflow to be fetched.
@@ -97,44 +97,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_register.rst
+++ b/docs/source/gen/flytectl_register.rst
@@ -28,44 +28,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_register_examples.rst
+++ b/docs/source/gen/flytectl_register_examples.rst
@@ -41,44 +41,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_register_files.rst
+++ b/docs/source/gen/flytectl_register_files.rst
@@ -95,44 +95,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_sandbox.rst
+++ b/docs/source/gen/flytectl_sandbox.rst
@@ -34,44 +34,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_sandbox_start.rst
+++ b/docs/source/gen/flytectl_sandbox_start.rst
@@ -13,8 +13,12 @@ Synopsis
 Start will run the flyte sandbox cluster inside a docker container and setup the config that is required 
 ::
 
- bin/flytectl start
+ bin/flytectl sandbox start
+	
+Mount your flytesnacks repository code inside sandbox 
+::
 
+ bin/flytectl sandbox start --flytesnacks=$HOME/flyteorg/flytesnacks 
 Usage
 	
 
@@ -27,51 +31,18 @@ Options
 
 ::
 
-  -h, --help   help for start
+      --flytesnacks string    Path of your flytesnacks repository
+  -h, --help                 help for start
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_sandbox_teardown.rst
+++ b/docs/source/gen/flytectl_sandbox_teardown.rst
@@ -14,12 +14,7 @@ Teardown will remove docker container and all the flyte config
 ::
 
  bin/flytectl sandbox teardown 
-
-Stop will remove docker container and all the flyte config 
-::
-
- bin/flytectl sandbox stop 
-
+	
 
 Usage
 
@@ -40,44 +35,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update.rst
+++ b/docs/source/gen/flytectl_update.rst
@@ -30,44 +30,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_update_cluster-resource-attribute.rst
@@ -69,44 +69,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_update_execution-cluster-label.rst
@@ -62,44 +62,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_update_execution-queue-attribute.rst
@@ -73,44 +73,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_launchplan.rst
+++ b/docs/source/gen/flytectl_update_launchplan.rst
@@ -47,44 +47,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_plugin-override.rst
+++ b/docs/source/gen/flytectl_update_plugin-override.rst
@@ -75,44 +75,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_project.rst
+++ b/docs/source/gen/flytectl_update_project.rst
@@ -72,44 +72,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_update_task-resource-attribute.rst
@@ -75,44 +75,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_task.rst
+++ b/docs/source/gen/flytectl_update_task.rst
@@ -47,44 +47,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_update_workflow.rst
+++ b/docs/source/gen/flytectl_update_workflow.rst
@@ -47,44 +47,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~

--- a/docs/source/gen/flytectl_version.rst
+++ b/docs/source/gen/flytectl_version.rst
@@ -32,44 +32,10 @@ Options inherited from parent commands
 
 ::
 
-      --admin.authorizationHeader string           Custom metadata header to pass JWT
-      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
-      --admin.clientId string                      Client ID (default "flytepropeller")
-      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
-      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
-      --admin.insecure                             Use insecure connection.
-      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
-      --admin.maxRetries int                       Max number of gRPC retries (default 4)
-      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
-      --admin.pkceConfig.refreshTime string         (default "5m0s")
-      --admin.pkceConfig.timeout string             (default "15s")
-      --admin.scopes strings                       List of scopes to request
-      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
-      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
-  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
-  -d, --domain string                              Specifies the Flyte project's domain.
-      --logger.formatter.type string               Sets logging format type. (default "json")
-      --logger.level int                           Sets the minimum logging level. (default 4)
-      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
-      --logger.show-source                         Includes source code location in logs.
-  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
-  -p, --project string                             Specifies the Flyte project.
-      --root.domain string                         Specified the domain to work on.
-      --root.output string                         Specified the output type.
-      --root.project string                        Specifies the project to work on.
-      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
-      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
-      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
-      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
-      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
-      --storage.connection.endpoint string         URL for storage client to connect to.
-      --storage.connection.region string           Region to connect to. (default "us-east-1")
-      --storage.connection.secret-key string       Secret to use when accesskey is set.
-      --storage.container string                   Initial container to create -if it doesn't exist-.'
-      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
-      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
-      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
-      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")
+  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
+  -d, --domain string    Specifies the Flyte project's domain.
+  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML DOT DOTURL]. NOTE: dot, doturl are only supported for Workflow (default "TABLE")
+  -p, --project string   Specifies the Flyte project.
 
 SEE ALSO
 ~~~~~~~~


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

Much smaller command help output as this removes the derived flags which are not used right now in flytectl and aswell cannot be used until bind values is supported for all.

```
flytectl --help
flytectl is CLI tool written in go to interact with flyteadmin service

Usage:
  flytectl [command]

Available Commands:
  config      Runs various config commands, look at the help of this command to get a list of available commands..
  create      Used for creating various flyte resources including tasks/workflows/launchplans/executions/project.
  delete      Used for terminating/deleting various flyte resources including tasks/workflows/launchplans/executions/project.
  get         Used for fetching various flyte resources including tasks/workflows/launchplans/executions/project.
  help        Help about any command
  register    Registers tasks/workflows/launchplans from list of generated serialized files.
  sandbox     Used for testing flyte sandbox.
  update      Used for updating flyte resources eg: project.
  version     Used for fetching flyte version

Flags:
  -c, --config string    config file (default is $HOME/.flyte/config.yaml)
  -d, --domain string    Specifies the Flyte project's domain.
  -h, --help             help for flytectl
  -o, --output string    Specifies the output type - supported formats [TABLE JSON YAML] (default "TABLE")
  -p, --project string   Specifies the Flyte project.

Use "flytectl [command] --help" for more information about a command.
```


Instead of the current one.
```
bin/flytectl --help               
flytectl is CLI tool written in go to interact with flyteadmin service

Usage:
  flytectl [command]

Available Commands:
  config      Runs various config commands, look at the help of this command to get a list of available commands..
  create      Used for creating various flyte resources including tasks/workflows/launchplans/executions/project.
  delete      Used for terminating/deleting various flyte resources including tasks/workflows/launchplans/executions/project.
  get         Used for fetching various flyte resources including tasks/workflows/launchplans/executions/project.
  help        Help about any command
  register    Registers tasks/workflows/launchplans from list of generated serialized files.
  sandbox     Used for testing flyte sandbox.
  update      Used for updating flyte resources eg: project.
  version     Used for fetching flyte version

Flags:
      --admin.authorizationHeader string           Custom metadata header to pass JWT
      --admin.authorizationServerUrl string        This is the URL to your IdP's authorization server. It'll default to Endpoint
      --admin.clientId string                      Client ID (default "flytepropeller")
      --admin.clientSecretLocation string          File containing the client secret (default "/etc/secrets/client_secret")
      --admin.endpoint string                      For admin types,  specify where the uri of the service is located.
      --admin.insecure                             Use insecure connection.
      --admin.maxBackoffDelay string               Max delay for grpc backoff (default "8s")
      --admin.maxRetries int                       Max number of gRPC retries (default 4)
      --admin.perRetryTimeout string               gRPC per retry timeout (default "15s")
      --admin.pkceConfig.refreshTime string         (default "5m0s")
      --admin.pkceConfig.timeout string             (default "15s")
      --admin.scopes strings                       List of scopes to request
      --admin.tokenUrl string                      OPTIONAL: Your IdP's token endpoint. It'll be discovered from flyte admin's OAuth Metadata endpoint if not provided.
      --admin.useAuth                              Deprecated: Auth will be enabled/disabled based on admin's dynamically discovered information.
  -c, --config string                              config file (default is $HOME/.flyte/config.yaml)
  -d, --domain string                              Specifies the Flyte project's domain.
  -h, --help                                       help for flytectl
      --logger.formatter.type string               Sets logging format type. (default "json")
      --logger.level int                           Sets the minimum logging level. (default 4)
      --logger.mute                                Mutes all logs regardless of severity. Intended for benchmarks/tests only.
      --logger.show-source                         Includes source code location in logs.
  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML] (default "TABLE")
  -p, --project string                             Specifies the Flyte project.
      --root.domain string                         Specified the domain to work on.
      --root.output string                         Specified the output type.
      --root.project string                        Specifies the project to work on.
      --storage.cache.max_size_mbs int             Maximum size of the cache where the Blob store data is cached in-memory. If not specified or set to 0,  cache is not used
      --storage.cache.target_gc_percent int        Sets the garbage collection target percentage.
      --storage.connection.access-key string       Access key to use. Only required when authtype is set to accesskey.
      --storage.connection.auth-type string        Auth Type to use [iam, accesskey]. (default "iam")
      --storage.connection.disable-ssl             Disables SSL connection. Should only be used for development.
      --storage.connection.endpoint string         URL for storage client to connect to.
      --storage.connection.region string           Region to connect to. (default "us-east-1")
      --storage.connection.secret-key string       Secret to use when accesskey is set.
      --storage.container string                   Initial container to create -if it doesn't exist-.'
      --storage.defaultHttpClient.timeout string   Sets time out on the http client. (default "0s")
      --storage.enable-multicontainer              If this is true,  then the container argument is overlooked and redundant. This config will automatically open new connections to new containers/buckets as they are encountered
      --storage.limits.maxDownloadMBs int          Maximum allowed download size (in MBs) per call. (default 2)
      --storage.type string                        Sets the type of storage to configure [s3/minio/local/mem/stow]. (default "s3")

Use "flytectl [command] --help" for more information about a command.
```

Has confusing clashing one like
```
  -d, --domain string                              Specifies the Flyte project's domain.
  -h, --help                                       help for flytectl
  -o, --output string                              Specifies the output type - supported formats [TABLE JSON YAML] (default "TABLE")
  -p, --project string                             Specifies the Flyte project.
      --root.domain string                         Specified the domain to work on.
      --root.output string                         Specified the output type.
      --root.project string                        Specifies the project to work on.
```

Docs available here https://docs.flyte.org/projects/flytectl/en/pmahindrakar-remove-parent-flags/

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
