### PR TITLE
#minor Node executions

### DIFF
--- a/cmd/config/subcommand/execution/config_flags.go
+++ b/cmd/config/subcommand/execution/config_flags.go
@@ -50,9 +50,11 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
-	cmdFlags.StringVar(&(DefaultConfig.Filter.FieldSelector), fmt.Sprintf("%v%v", prefix, "filter.field-selector"), *new(string), "Specifies the Field selector")
-	cmdFlags.StringVar((&DefaultConfig.Filter.SortBy), fmt.Sprintf("%v%v", prefix, "filter.sort-by"), *new(string), "Specifies which field to sort result by ")
-	cmdFlags.Int32Var((&DefaultConfig.Filter.Limit), fmt.Sprintf("%v%v", prefix, "filter.limit"), 100, "Specifies the limit")
-	cmdFlags.BoolVar((&DefaultConfig.Filter.Asc), fmt.Sprintf("%v%v", prefix, "filter.asc"), false, "Specifies the sorting order. By default flytectl sort result in descending order")
+	cmdFlags.StringVar(&DefaultConfig.Filter.FieldSelector, fmt.Sprintf("%v%v", prefix, "filter.field-selector"), DefaultConfig.Filter.FieldSelector, "Specifies the Field selector")
+	cmdFlags.StringVar(&DefaultConfig.Filter.SortBy, fmt.Sprintf("%v%v", prefix, "filter.sort-by"), DefaultConfig.Filter.SortBy, "Specifies which field to sort results ")
+	cmdFlags.Int32Var(&DefaultConfig.Filter.Limit, fmt.Sprintf("%v%v", prefix, "filter.limit"), DefaultConfig.Filter.Limit, "Specifies the limit")
+	cmdFlags.BoolVar(&DefaultConfig.Filter.Asc, fmt.Sprintf("%v%v", prefix, "filter.asc"), DefaultConfig.Filter.Asc, "Specifies the sorting order. By default flytectl sort result in descending order")
+	cmdFlags.BoolVar(&DefaultConfig.Details, fmt.Sprintf("%v%v", prefix, "details"), DefaultConfig.Details, "gets node execution details. Only applicable for single execution name i.e get execution name --details")
+	cmdFlags.StringVar(&DefaultConfig.NodeID, fmt.Sprintf("%v%v", prefix, "nodeId"), DefaultConfig.NodeID, "get task executions for given node name.")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/execution/config_flags_test.go
+++ b/cmd/config/subcommand/execution/config_flags_test.go
@@ -155,4 +155,32 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_details", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("details", testValue)
+			if vBool, err := cmdFlags.GetBool("details"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.Details)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
+	t.Run("Test_nodeId", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("nodeId", testValue)
+			if vString, err := cmdFlags.GetString("nodeId"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.NodeID)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/cmd/config/subcommand/execution/execution_config.go
+++ b/cmd/config/subcommand/execution/execution_config.go
@@ -4,14 +4,16 @@ import (
 	"github.com/flyteorg/flytectl/pkg/filters"
 )
 
-//go:generate pflags Config --default-var DefaultConfig
+//go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
 		Filter: filters.DefaultFilter,
 	}
 )
 
-// Config
+// Config stores the flags required by get execution
 type Config struct {
-	Filter filters.Filters `json:"filter" pflag:","`
+	Filter  filters.Filters `json:"filter" pflag:","`
+	Details bool            `json:"details" pflag:",gets node execution details. Only applicable for single execution name i.e get execution name --details"`
+	NodeID  string          `json:"nodeId" pflag:",get task executions for given node name."`
 }

--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -9,6 +9,7 @@ import (
 	"github.com/flyteorg/flytectl/pkg/printer"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flytestdlib/logger"
+
 	"github.com/golang/protobuf/proto"
 )
 
@@ -50,6 +51,31 @@ Retrieves all the execution within project and domain in json format.
 
  bin/flytectl get execution -p flytesnacks -d development -o json
 
+
+Get more details for the execution using --details flag which shows node executions along with task executions on them. Default view is tree view and TABLE format is not supported on this view
+
+::
+
+ bin/flytectl get execution -p flytesnacks -d development oeh94k9r2r --details
+
+Using yaml view for the details. In this view only node details are available. For task details pass --nodeId flag
+
+::
+
+ bin/flytectl get execution -p flytesnacks -d development oeh94k9r2r --details -o yaml
+
+Using --nodeId flag to get task executions on a specific node. Use the nodeId attribute from node details view
+
+::
+
+ bin/flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodId n0
+
+Task execution view is also available in yaml/json format. Below example shows yaml
+
+::
+
+ bin/flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodId n0 -o yaml
+
 Usage
 `
 )
@@ -86,6 +112,11 @@ func getExecutionFunc(ctx context.Context, args []string, cmdCtx cmdCore.Command
 		}
 		executions = append(executions, exec)
 		logger.Infof(ctx, "Retrieved %v executions", len(executions))
+
+		if execution.DefaultConfig.Details || len(execution.DefaultConfig.NodeID) > 0 {
+			// Fetching Node execution details
+			return getExecutionDetails(ctx, config.GetConfig().Project, config.GetConfig().Domain, name, cmdCtx)
+		}
 		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), executionColumns,
 			ExecutionToProtoMessages(executions)...)
 	}

--- a/cmd/get/node_execution.go
+++ b/cmd/get/node_execution.go
@@ -1,0 +1,202 @@
+package get
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/flyteorg/flytectl/cmd/config"
+	"github.com/flyteorg/flytectl/cmd/config/subcommand/execution"
+	cmdCore "github.com/flyteorg/flytectl/cmd/core"
+	"github.com/flyteorg/flytectl/pkg/printer"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flytestdlib/logger"
+
+	"github.com/disiqueira/gotree"
+	"github.com/golang/protobuf/proto"
+)
+
+var nodeExecutionColumns = []printer.Column{
+	{Header: "Name", JSONPath: "$.id.nodeID"},
+	{Header: "Exec", JSONPath: "$.id.executionId.name"},
+	{Header: "Duration", JSONPath: "$.closure.duration"},
+	{Header: "StartedAt", JSONPath: "$.closure.startedAt"},
+	{Header: "Phase", JSONPath: "$.closure.phase"},
+}
+
+var taskExecutionColumns = []printer.Column{
+	{Header: "Name", JSONPath: "$.id.taskId.name"},
+	{Header: "Node ID", JSONPath: "$.id.nodeExecutionId.nodeID"},
+	{Header: "Execution ID", JSONPath: "$.closure.nodeExecutionId.executionId.name"},
+	{Header: "Duration", JSONPath: "$.closure.duration"},
+	{Header: "StartedAt", JSONPath: "$.closure.startedAt"},
+	{Header: "Phase", JSONPath: "$.closure.phase"},
+}
+
+const (
+	taskAttemptPrefix          = "Attempt :"
+	taskExecPrefix             = "Task - "
+	taskTypePrefix             = "Task Type - "
+	taskReasonPrefix           = "Reason - "
+	taskMetadataPrefix         = "Metadata"
+	taskGeneratedNamePrefix    = "Generated Name : "
+	taskPluginIDPrefix         = "Plugin Identifier : "
+	taskExtResourcesPrefix     = "External Resources"
+	taskExtResourcePrefix      = "Ext Resource : "
+	taskExtResourceTokenPrefix = "Ext Resource Token : " //nolint
+	taskResourcePrefix         = "Resource Pool Info"
+	taskLogsPrefix             = "Logs :"
+	taskLogsNamePrefix         = "Name :"
+	taskLogURIPrefix           = "URI :"
+	hyphenPrefix               = " - "
+)
+
+func NodeExecutionToProtoMessages(l []*admin.NodeExecution) []proto.Message {
+	messages := make([]proto.Message, 0, len(l))
+	for _, m := range l {
+		messages = append(messages, m)
+	}
+	return messages
+}
+
+func NodeTaskExecutionToProtoMessages(l []*admin.TaskExecution) []proto.Message {
+	messages := make([]proto.Message, 0, len(l))
+	for _, m := range l {
+		messages = append(messages, m)
+	}
+	return messages
+}
+
+func getExecutionDetails(ctx context.Context, project, domain, name string, cmdCtx cmdCore.CommandContext) error {
+	adminPrinter := printer.Printer{}
+
+	// Fetching Node execution details
+	nExecDetails, nodeExecToTaskExec, err := getNodeExecDetailsWithTasks(ctx, project, domain, name, cmdCtx)
+	if err != nil {
+		return err
+	}
+
+	// o/p format of table is not supported on the details. TODO: Add tree format in printer
+	if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
+		fmt.Println("TABLE format is not supported on detailed view and defaults to tree view. Choose either json/yaml")
+		if len(execution.DefaultConfig.NodeID) == 0 {
+			nodeExecTree := createNodeDetailsTreeView(nExecDetails, nodeExecToTaskExec)
+			if nodeExecTree != nil {
+				fmt.Println(nodeExecTree.Print())
+			}
+		} else {
+			nodeTaskExecTree := createNodeTaskExecTreeView(nil, nodeExecToTaskExec[execution.DefaultConfig.NodeID])
+			if nodeTaskExecTree != nil {
+				fmt.Println(nodeTaskExecTree.Print())
+			}
+		}
+		return nil
+	}
+
+	if len(execution.DefaultConfig.NodeID) == 0 {
+		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), nodeExecutionColumns,
+			NodeExecutionToProtoMessages(nExecDetails)...)
+	}
+
+	taskExecList := nodeExecToTaskExec[execution.DefaultConfig.NodeID]
+	if taskExecList != nil {
+		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), taskExecutionColumns,
+			NodeTaskExecutionToProtoMessages(taskExecList.TaskExecutions)...)
+	}
+	return nil
+}
+
+func getNodeExecDetailsWithTasks(ctx context.Context, project, domain, name string, cmdCtx cmdCore.CommandContext) (
+	[]*admin.NodeExecution, map[string]*admin.TaskExecutionList, error) {
+	// Fetching Node execution details
+	nExecDetails, err := cmdCtx.AdminFetcherExt().FetchNodeExecutionDetails(ctx, name, project, domain)
+	if err != nil {
+		return nil, nil, err
+	}
+	logger.Infof(ctx, "Retrieved %v node executions", len(nExecDetails.NodeExecutions))
+
+	// Mapping node execution id to task list
+	nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+	for _, nodeExec := range nExecDetails.NodeExecutions {
+		nodeExecToTaskExec[nodeExec.Id.NodeId], err = cmdCtx.AdminFetcherExt().FetchTaskExecutionsOnNode(ctx,
+			nodeExec.Id.NodeId, name, project, domain)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return nExecDetails.NodeExecutions, nodeExecToTaskExec, nil
+}
+
+func createNodeTaskExecTreeView(rootView gotree.Tree, taskExecs *admin.TaskExecutionList) gotree.Tree {
+	if taskExecs == nil || len(taskExecs.TaskExecutions) == 0 {
+		return gotree.New("")
+	}
+	if rootView == nil {
+		rootView = gotree.New("")
+	}
+	// TODO: Replace this by filter to sort in the admin
+	sort.Slice(taskExecs.TaskExecutions[:], func(i, j int) bool {
+		return taskExecs.TaskExecutions[i].Id.RetryAttempt < taskExecs.TaskExecutions[j].Id.RetryAttempt
+	})
+	for _, taskExec := range taskExecs.TaskExecutions {
+		attemptView := rootView.Add(taskAttemptPrefix + strconv.Itoa(int(taskExec.Id.RetryAttempt)))
+		attemptView.Add(taskExecPrefix + taskExec.Closure.Phase.String() +
+			hyphenPrefix + taskExec.Closure.StartedAt.AsTime().String() +
+			hyphenPrefix + taskExec.Closure.StartedAt.AsTime().
+			Add(taskExec.Closure.Duration.AsDuration()).String())
+		attemptView.Add(taskTypePrefix + taskExec.Closure.TaskType)
+		attemptView.Add(taskReasonPrefix + taskExec.Closure.Reason)
+		if taskExec.Closure.Metadata != nil {
+			metadata := attemptView.Add(taskMetadataPrefix)
+			metadata.Add(taskGeneratedNamePrefix + taskExec.Closure.Metadata.GeneratedName)
+			metadata.Add(taskPluginIDPrefix + taskExec.Closure.Metadata.PluginIdentifier)
+			extResourcesView := metadata.Add(taskExtResourcesPrefix)
+			for _, extResource := range taskExec.Closure.Metadata.ExternalResources {
+				extResourcesView.Add(taskExtResourcePrefix + extResource.ExternalId)
+			}
+			resourcePoolInfoView := metadata.Add(taskResourcePrefix)
+			for _, rsPool := range taskExec.Closure.Metadata.ResourcePoolInfo {
+				resourcePoolInfoView.Add(taskExtResourcePrefix + rsPool.Namespace)
+				resourcePoolInfoView.Add(taskExtResourceTokenPrefix + rsPool.AllocationToken)
+			}
+		}
+
+		sort.Slice(taskExec.Closure.Logs[:], func(i, j int) bool {
+			return taskExec.Closure.Logs[i].Name < taskExec.Closure.Logs[j].Name
+		})
+
+		logsView := attemptView.Add(taskLogsPrefix)
+		for _, logData := range taskExec.Closure.Logs {
+			logsView.Add(taskLogsNamePrefix + logData.Name)
+			logsView.Add(taskLogURIPrefix + logData.Uri)
+		}
+	}
+
+	return rootView
+}
+
+func createNodeDetailsTreeView(nodeExecutions []*admin.NodeExecution, nodeExecToTaskExec map[string]*admin.TaskExecutionList) gotree.Tree {
+	nodeDetailsTreeView := gotree.New("")
+	if nodeExecutions == nil || nodeExecToTaskExec == nil {
+		return nodeDetailsTreeView
+	}
+	// TODO : Move to sorting using filters.
+	sort.Slice(nodeExecutions[:], func(i, j int) bool {
+		// TODO : Remove this after fixing the StartedAt and Duration field not being populated for start-node and end-node in Admin
+		if nodeExecutions[i].Closure.StartedAt == nil || nodeExecutions[j].Closure.StartedAt == nil {
+			return true
+		}
+		return nodeExecutions[i].Closure.StartedAt.Nanos < nodeExecutions[j].Closure.StartedAt.Nanos
+	})
+
+	for _, nodeExec := range nodeExecutions {
+		nExecView := nodeDetailsTreeView.Add(nodeExec.Id.NodeId + hyphenPrefix + nodeExec.Closure.Phase.String() +
+			hyphenPrefix + nodeExec.Closure.StartedAt.AsTime().String() +
+			hyphenPrefix + nodeExec.Closure.StartedAt.AsTime().
+			Add(nodeExec.Closure.Duration.AsDuration()).String())
+		taskExecs := nodeExecToTaskExec[nodeExec.Id.NodeId]
+		createNodeTaskExecTreeView(nExecView, taskExecs)
+	}
+	return nodeDetailsTreeView
+}

--- a/cmd/get/node_execution_test.go
+++ b/cmd/get/node_execution_test.go
@@ -1,0 +1,322 @@
+package get
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/flyteorg/flytectl/cmd/config"
+	"github.com/flyteorg/flytectl/cmd/config/subcommand/execution"
+	u "github.com/flyteorg/flytectl/cmd/testutils"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
+
+	"github.com/disiqueira/gotree"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	dummyProject = "dummyProject"
+	dummyDomain  = "dummyDomain"
+	dummyExec    = "dummyExec"
+)
+
+func TestCreateNodeDetailsTreeView(t *testing.T) {
+
+	t.Run("empty node execution", func(t *testing.T) {
+		var nodeExecutions []*admin.NodeExecution
+		var nodeExecToTaskExec map[string]*admin.TaskExecutionList
+		expectedRoot := gotree.New("")
+		treeRoot := createNodeDetailsTreeView(nodeExecutions, nodeExecToTaskExec)
+		assert.Equal(t, expectedRoot, treeRoot)
+	})
+
+	t.Run("successful simple node execution full view", func(t *testing.T) {
+		nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+
+		nodeExec1 := createDummyNodeWithID("start-node", true)
+		taskExec11 := createDummyTaskExecutionForNode("start-node", "task11")
+		taskExec12 := createDummyTaskExecutionForNode("start-node", "task12")
+
+		nodeExecToTaskExec["start-node"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec11, taskExec12},
+		}
+
+		nodeExec2 := createDummyNodeWithID("n0", false)
+		taskExec21 := createDummyTaskExecutionForNode("n0", "task21")
+		taskExec22 := createDummyTaskExecutionForNode("n0", "task22")
+
+		nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec21, taskExec22},
+		}
+
+		nodeExec3 := createDummyNodeWithID("n1", false)
+		taskExec31 := createDummyTaskExecutionForNode("n1", "task31")
+		taskExec32 := createDummyTaskExecutionForNode("n1", "task32")
+
+		nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec31, taskExec32},
+		}
+
+		nodeExecutions := []*admin.NodeExecution{nodeExec1, nodeExec2, nodeExec3}
+
+		treeRoot := createNodeDetailsTreeView(nodeExecutions, nodeExecToTaskExec)
+
+		assert.Equal(t, 3, len(treeRoot.Items()))
+	})
+
+	t.Run("empty task execution only view", func(t *testing.T) {
+		taskExecutionList := &admin.TaskExecutionList{}
+		treeRoot := createNodeTaskExecTreeView(nil, taskExecutionList)
+		assert.Equal(t, 0, len(treeRoot.Items()))
+	})
+
+	t.Run("successful task execution only view", func(t *testing.T) {
+		taskExec31 := createDummyTaskExecutionForNode("n1", "task31")
+		taskExec32 := createDummyTaskExecutionForNode("n1", "task32")
+
+		taskExecutionList := &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec31, taskExec32},
+		}
+
+		treeRoot := createNodeTaskExecTreeView(nil, taskExecutionList)
+		assert.Equal(t, 2, len(treeRoot.Items()))
+	})
+}
+
+func createDummyNodeWithID(nodeID string, startedAtEmpty bool) *admin.NodeExecution {
+	// Remove this param  startedAtEmpty and code once admin code is fixed
+	startedAt := timestamppb.Now()
+	if startedAtEmpty {
+		startedAt = nil
+	}
+
+	nodeExecution := &admin.NodeExecution{
+		Id: &core.NodeExecutionIdentifier{
+			NodeId: nodeID,
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: dummyProject,
+				Domain:  dummyDomain,
+				Name:    dummyExec,
+			},
+		},
+		InputUri: nodeID + "inputUri",
+		Closure: &admin.NodeExecutionClosure{
+			OutputResult: &admin.NodeExecutionClosure_OutputUri{
+				OutputUri: nodeID + "outputUri",
+			},
+			Phase:     core.NodeExecution_SUCCEEDED,
+			StartedAt: startedAt,
+			Duration:  &durationpb.Duration{Seconds: 100},
+			CreatedAt: timestamppb.Now(),
+			UpdatedAt: timestamppb.Now(),
+			TargetMetadata: &admin.NodeExecutionClosure_WorkflowNodeMetadata{
+				WorkflowNodeMetadata: &admin.WorkflowNodeMetadata{
+					ExecutionId: &core.WorkflowExecutionIdentifier{
+						Project: dummyProject,
+						Domain:  dummyDomain,
+						Name:    dummyExec,
+					},
+				},
+			},
+		},
+	}
+	return nodeExecution
+}
+
+func createDummyTaskExecutionForNode(nodeID string, taskID string) *admin.TaskExecution {
+	taskLog1 := &core.TaskLog{
+		Uri:           nodeID + taskID + "logUri1",
+		Name:          nodeID + taskID + "logName1",
+		MessageFormat: core.TaskLog_JSON,
+		Ttl:           &durationpb.Duration{Seconds: 100},
+	}
+
+	taskLog2 := &core.TaskLog{
+		Uri:           nodeID + taskID + "logUri2",
+		Name:          nodeID + taskID + "logName2",
+		MessageFormat: core.TaskLog_JSON,
+		Ttl:           &durationpb.Duration{Seconds: 100},
+	}
+
+	taskLogs := []*core.TaskLog{taskLog1, taskLog2}
+
+	extResourceInfo := &event.ExternalResourceInfo{
+		ExternalId: nodeID + taskID + "externalId",
+	}
+	extResourceInfos := []*event.ExternalResourceInfo{extResourceInfo}
+
+	resourcePoolInfo := &event.ResourcePoolInfo{
+		AllocationToken: nodeID + taskID + "allocationToken",
+		Namespace:       nodeID + taskID + "namespace",
+	}
+	resourcePoolInfos := []*event.ResourcePoolInfo{resourcePoolInfo}
+
+	taskExec := &admin.TaskExecution{
+		Id: &core.TaskExecutionIdentifier{
+			TaskId: &core.Identifier{
+				Project:      dummyProject,
+				Domain:       dummyDomain,
+				Name:         dummyExec,
+				ResourceType: core.ResourceType_TASK,
+			},
+		},
+		InputUri: nodeID + taskID + "inputUrlForTask",
+		Closure: &admin.TaskExecutionClosure{
+			OutputResult: &admin.TaskExecutionClosure_OutputUri{
+				OutputUri: nodeID + taskID + "outputUri-task",
+			},
+			Phase:     core.TaskExecution_SUCCEEDED,
+			Logs:      taskLogs,
+			StartedAt: timestamppb.Now(),
+			Duration:  &durationpb.Duration{Seconds: 100},
+			CreatedAt: timestamppb.Now(),
+			UpdatedAt: timestamppb.New(time.Now()),
+			Reason:    nodeID + taskID + "reason",
+			TaskType:  nodeID + taskID + "taskType",
+			Metadata: &event.TaskExecutionMetadata{
+				GeneratedName:     nodeID + taskID + "generatedName",
+				ExternalResources: extResourceInfos,
+				ResourcePoolInfo:  resourcePoolInfos,
+				PluginIdentifier:  nodeID + taskID + "pluginId",
+			},
+		},
+	}
+	return taskExec
+}
+
+func TestGetExecutionDetails(t *testing.T) {
+	t.Run("successful get details default view", func(t *testing.T) {
+		setup()
+		ctx := u.Ctx
+		mockCmdCtx := u.CmdCtx
+		mockFetcherExt := u.FetcherExt
+		nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+
+		nodeExec1 := createDummyNodeWithID("n0", false)
+		taskExec1 := createDummyTaskExecutionForNode("n0", "task21")
+		taskExec2 := createDummyTaskExecutionForNode("n0", "task22")
+
+		nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec1, taskExec2},
+		}
+
+		nodeExecutions := []*admin.NodeExecution{nodeExec1}
+		nodeExecList := &admin.NodeExecutionList{NodeExecutions: nodeExecutions}
+
+		mockFetcherExt.OnFetchNodeExecutionDetailsMatch(ctx, dummyExec, dummyProject, dummyDomain).Return(nodeExecList, nil)
+		mockFetcherExt.OnFetchTaskExecutionsOnNodeMatch(ctx, "n0", dummyExec, dummyProject, dummyDomain).Return(nodeExecToTaskExec["n0"], nil)
+
+		err = getExecutionDetails(ctx, dummyProject, dummyDomain, dummyExec, mockCmdCtx)
+		assert.Nil(t, err)
+	})
+
+	t.Run("failure node details fetch", func(t *testing.T) {
+		setup()
+		ctx := u.Ctx
+		mockCmdCtx := u.CmdCtx
+		mockFetcherExt := u.FetcherExt
+		mockFetcherExt.OnFetchNodeExecutionDetailsMatch(ctx, dummyExec, dummyProject, dummyDomain).Return(nil, fmt.Errorf("unable to fetch details"))
+		err = getExecutionDetails(ctx, dummyProject, dummyDomain, dummyExec, mockCmdCtx)
+		assert.NotNil(t, err)
+		assert.Equal(t, fmt.Errorf("unable to fetch details"), err)
+	})
+
+	t.Run("failure task exec fetch", func(t *testing.T) {
+		setup()
+		ctx := u.Ctx
+		mockCmdCtx := u.CmdCtx
+		mockFetcherExt := u.FetcherExt
+		nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+
+		nodeExec1 := createDummyNodeWithID("n0", false)
+		taskExec1 := createDummyTaskExecutionForNode("n0", "task21")
+		taskExec2 := createDummyTaskExecutionForNode("n0", "task22")
+
+		nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec1, taskExec2},
+		}
+
+		nodeExecutions := []*admin.NodeExecution{nodeExec1}
+		nodeExecList := &admin.NodeExecutionList{NodeExecutions: nodeExecutions}
+
+		mockFetcherExt.OnFetchNodeExecutionDetailsMatch(ctx, dummyExec, dummyProject, dummyDomain).Return(nodeExecList, nil)
+		mockFetcherExt.OnFetchTaskExecutionsOnNodeMatch(ctx, "n0", dummyExec, dummyProject, dummyDomain).Return(nil, fmt.Errorf("unable to fetch task exec details"))
+		err = getExecutionDetails(ctx, dummyProject, dummyDomain, dummyExec, mockCmdCtx)
+		assert.NotNil(t, err)
+		assert.Equal(t, fmt.Errorf("unable to fetch task exec details"), err)
+	})
+
+	t.Run("successful get details non default view", func(t *testing.T) {
+		setup()
+		config.GetConfig().Output = "table"
+		execution.DefaultConfig.NodeID = "n0"
+
+		ctx := u.Ctx
+		mockCmdCtx := u.CmdCtx
+		mockFetcherExt := u.FetcherExt
+		nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+
+		nodeExec1 := createDummyNodeWithID("n0", false)
+		taskExec1 := createDummyTaskExecutionForNode("n0", "task21")
+		taskExec2 := createDummyTaskExecutionForNode("n0", "task22")
+
+		nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+			TaskExecutions: []*admin.TaskExecution{taskExec1, taskExec2},
+		}
+
+		nodeExecutions := []*admin.NodeExecution{nodeExec1}
+		nodeExecList := &admin.NodeExecutionList{NodeExecutions: nodeExecutions}
+
+		mockFetcherExt.OnFetchNodeExecutionDetailsMatch(ctx, dummyExec, dummyProject, dummyDomain).Return(nodeExecList, nil)
+		mockFetcherExt.OnFetchTaskExecutionsOnNodeMatch(ctx, "n0", dummyExec, dummyProject, dummyDomain).Return(nodeExecToTaskExec["n0"], nil)
+
+		err = getExecutionDetails(ctx, dummyProject, dummyDomain, dummyExec, mockCmdCtx)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Table test successful cases", func(t *testing.T) {
+		tests := []struct {
+			outputFormat string
+			nodeID       string
+			want         error
+		}{
+			{outputFormat: "table", nodeID: "", want: nil},
+			{outputFormat: "table", nodeID: "n0", want: nil},
+			{outputFormat: "yaml", nodeID: "", want: nil},
+			{outputFormat: "yaml", nodeID: "n0", want: nil},
+			{outputFormat: "yaml", nodeID: "n1", want: nil},
+		}
+
+		for _, tt := range tests {
+			setup()
+			config.GetConfig().Output = tt.outputFormat
+			execution.DefaultConfig.NodeID = tt.nodeID
+
+			ctx := u.Ctx
+			mockCmdCtx := u.CmdCtx
+			mockFetcherExt := u.FetcherExt
+			nodeExecToTaskExec := map[string]*admin.TaskExecutionList{}
+
+			nodeExec1 := createDummyNodeWithID("n0", false)
+			taskExec1 := createDummyTaskExecutionForNode("n0", "task21")
+			taskExec2 := createDummyTaskExecutionForNode("n0", "task22")
+
+			nodeExecToTaskExec["n0"] = &admin.TaskExecutionList{
+				TaskExecutions: []*admin.TaskExecution{taskExec1, taskExec2},
+			}
+
+			nodeExecutions := []*admin.NodeExecution{nodeExec1}
+			nodeExecList := &admin.NodeExecutionList{NodeExecutions: nodeExecutions}
+
+			mockFetcherExt.OnFetchNodeExecutionDetailsMatch(ctx, dummyExec, dummyProject, dummyDomain).Return(nodeExecList, nil)
+			mockFetcherExt.OnFetchTaskExecutionsOnNodeMatch(ctx, "n0", dummyExec, dummyProject, dummyDomain).Return(nodeExecToTaskExec["n0"], nil)
+
+			got := getExecutionDetails(ctx, dummyProject, dummyDomain, dummyExec, mockCmdCtx)
+			assert.Equal(t, tt.want, got)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/containerd/containerd v1.5.2 // indirect
+	github.com/disiqueira/gotree v1.0.0
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/enescakir/emoji v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -292,6 +292,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/disiqueira/gotree v1.0.0 h1:en5wk87n7/Jyk6gVME3cx3xN9KmUCstJ1IjHr4Se4To=
+github.com/disiqueira/gotree v1.0.0/go.mod h1:7CwL+VWsWAU95DovkdRZAtA7YbtHwGk+tLV/kNi8niU=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=

--- a/pkg/ext/execution_fetcher.go
+++ b/pkg/ext/execution_fetcher.go
@@ -23,6 +23,39 @@ func (a *AdminFetcherExtClient) FetchExecution(ctx context.Context, name, projec
 	return e, nil
 }
 
+func (a *AdminFetcherExtClient) FetchNodeExecutionDetails(ctx context.Context, name, project, domain string) (*admin.NodeExecutionList, error) {
+	ne, err := a.AdminServiceClient().ListNodeExecutions(ctx, &admin.NodeExecutionListRequest{
+		WorkflowExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: project,
+			Domain:  domain,
+			Name:    name,
+		},
+		Limit: 100,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ne, nil
+}
+
+func (a *AdminFetcherExtClient) FetchTaskExecutionsOnNode(ctx context.Context, nodeID, execName, project, domain string) (*admin.TaskExecutionList, error) {
+	te, err := a.AdminServiceClient().ListTaskExecutions(ctx, &admin.TaskExecutionListRequest{
+		NodeExecutionId: &core.NodeExecutionIdentifier{
+			NodeId: nodeID,
+			ExecutionId: &core.WorkflowExecutionIdentifier{
+				Project: project,
+				Domain:  domain,
+				Name:    execName,
+			},
+		},
+		Limit: 100,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return te, nil
+}
+
 func (a *AdminFetcherExtClient) ListExecution(ctx context.Context, project, domain string, filter filters.Filters) (*admin.ExecutionList, error) {
 	transformFilters, err := filters.BuildResourceListRequestWithName(filter, project, domain, "")
 	if err != nil {

--- a/pkg/ext/execution_fetcher_test.go
+++ b/pkg/ext/execution_fetcher_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flyteorg/flyteidl/clients/go/admin/mocks"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -64,5 +65,33 @@ func TestFetchExecutionError(t *testing.T) {
 	getExecutionFetcherSetup()
 	adminClient.OnGetExecutionMatch(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
 	_, err := adminFetcherExt.FetchExecution(ctx, "execName", "dummyProject", "domainValue")
+	assert.Equal(t, fmt.Errorf("failed"), err)
+}
+
+func TestFetchNodeExecutionDetails(t *testing.T) {
+	getExecutionFetcherSetup()
+	adminClient.OnListNodeExecutionsMatch(mock.Anything, mock.Anything).Return(&admin.NodeExecutionList{}, nil)
+	_, err := adminFetcherExt.FetchNodeExecutionDetails(ctx, "execName", "dummyProject", "domainValue")
+	assert.Nil(t, err)
+}
+
+func TestFetchNodeExecutionDetailsError(t *testing.T) {
+	getExecutionFetcherSetup()
+	adminClient.OnListNodeExecutionsMatch(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
+	_, err := adminFetcherExt.FetchNodeExecutionDetails(ctx, "execName", "dummyProject", "domainValue")
+	assert.Equal(t, fmt.Errorf("failed"), err)
+}
+
+func TestFetchTaskExecOnNode(t *testing.T) {
+	getExecutionFetcherSetup()
+	adminClient.OnListTaskExecutionsMatch(mock.Anything, mock.Anything).Return(&admin.TaskExecutionList{}, nil)
+	_, err := adminFetcherExt.FetchTaskExecutionsOnNode(ctx, "nodeId", "execName", "dummyProject", "domainValue")
+	assert.Nil(t, err)
+}
+
+func TestFetchTaskExecOnNodeError(t *testing.T) {
+	getExecutionFetcherSetup()
+	adminClient.OnListTaskExecutionsMatch(mock.Anything, mock.Anything).Return(nil, fmt.Errorf("failed"))
+	_, err := adminFetcherExt.FetchTaskExecutionsOnNode(ctx, "nodeId", "execName", "dummyProject", "domainValue")
 	assert.Equal(t, fmt.Errorf("failed"), err)
 }

--- a/pkg/ext/fetcher.go
+++ b/pkg/ext/fetcher.go
@@ -19,6 +19,12 @@ type AdminFetcherExtInterface interface {
 	// FetchExecution fetches the execution based on name, project, domain
 	FetchExecution(ctx context.Context, name, project, domain string) (*admin.Execution, error)
 
+	// FetchNodeExecutionDetails fetches the node execution details based on execution name, project, domain
+	FetchNodeExecutionDetails(ctx context.Context, name, project, domain string) (*admin.NodeExecutionList, error)
+
+	// FetchTaskExecutionsOnNode fetches task execution on a node , for give execution name, project, domain
+	FetchTaskExecutionsOnNode(ctx context.Context, nodeID, execName, project, domain string) (*admin.TaskExecutionList, error)
+
 	// ListExecution fetches the all versions of  based on name, project, domain
 	ListExecution(ctx context.Context, project, domain string, filter filters.Filters) (*admin.ExecutionList, error)
 

--- a/pkg/ext/mocks/admin_fetcher_ext_interface.go
+++ b/pkg/ext/mocks/admin_fetcher_ext_interface.go
@@ -299,6 +299,47 @@ func (_m *AdminFetcherExtInterface) FetchLPVersion(ctx context.Context, name str
 	return r0, r1
 }
 
+type AdminFetcherExtInterface_FetchNodeExecutionDetails struct {
+	*mock.Call
+}
+
+func (_m AdminFetcherExtInterface_FetchNodeExecutionDetails) Return(_a0 *admin.NodeExecutionList, _a1 error) *AdminFetcherExtInterface_FetchNodeExecutionDetails {
+	return &AdminFetcherExtInterface_FetchNodeExecutionDetails{Call: _m.Call.Return(_a0, _a1)}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchNodeExecutionDetails(ctx context.Context, name string, project string, domain string) *AdminFetcherExtInterface_FetchNodeExecutionDetails {
+	c := _m.On("FetchNodeExecutionDetails", ctx, name, project, domain)
+	return &AdminFetcherExtInterface_FetchNodeExecutionDetails{Call: c}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchNodeExecutionDetailsMatch(matchers ...interface{}) *AdminFetcherExtInterface_FetchNodeExecutionDetails {
+	c := _m.On("FetchNodeExecutionDetails", matchers...)
+	return &AdminFetcherExtInterface_FetchNodeExecutionDetails{Call: c}
+}
+
+// FetchNodeExecutionDetails provides a mock function with given fields: ctx, name, project, domain
+func (_m *AdminFetcherExtInterface) FetchNodeExecutionDetails(ctx context.Context, name string, project string, domain string) (*admin.NodeExecutionList, error) {
+	ret := _m.Called(ctx, name, project, domain)
+
+	var r0 *admin.NodeExecutionList
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *admin.NodeExecutionList); ok {
+		r0 = rf(ctx, name, project, domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*admin.NodeExecutionList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
+		r1 = rf(ctx, name, project, domain)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type AdminFetcherExtInterface_FetchProjectDomainAttributes struct {
 	*mock.Call
 }
@@ -333,6 +374,47 @@ func (_m *AdminFetcherExtInterface) FetchProjectDomainAttributes(ctx context.Con
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, string, admin.MatchableResource) error); ok {
 		r1 = rf(ctx, project, domain, rsType)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+type AdminFetcherExtInterface_FetchTaskExecutionsOnNode struct {
+	*mock.Call
+}
+
+func (_m AdminFetcherExtInterface_FetchTaskExecutionsOnNode) Return(_a0 *admin.TaskExecutionList, _a1 error) *AdminFetcherExtInterface_FetchTaskExecutionsOnNode {
+	return &AdminFetcherExtInterface_FetchTaskExecutionsOnNode{Call: _m.Call.Return(_a0, _a1)}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchTaskExecutionsOnNode(ctx context.Context, nodeId string, execName string, project string, domain string) *AdminFetcherExtInterface_FetchTaskExecutionsOnNode {
+	c := _m.On("FetchTaskExecutionsOnNode", ctx, nodeId, execName, project, domain)
+	return &AdminFetcherExtInterface_FetchTaskExecutionsOnNode{Call: c}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchTaskExecutionsOnNodeMatch(matchers ...interface{}) *AdminFetcherExtInterface_FetchTaskExecutionsOnNode {
+	c := _m.On("FetchTaskExecutionsOnNode", matchers...)
+	return &AdminFetcherExtInterface_FetchTaskExecutionsOnNode{Call: c}
+}
+
+// FetchTaskExecutionsOnNode provides a mock function with given fields: ctx, nodeId, execName, project, domain
+func (_m *AdminFetcherExtInterface) FetchTaskExecutionsOnNode(ctx context.Context, nodeId string, execName string, project string, domain string) (*admin.TaskExecutionList, error) {
+	ret := _m.Called(ctx, nodeId, execName, project, domain)
+
+	var r0 *admin.TaskExecutionList
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) *admin.TaskExecutionList); ok {
+		r0 = rf(ctx, nodeId, execName, project, domain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*admin.TaskExecutionList)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = rf(ctx, nodeId, execName, project, domain)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
# TL;DR

Adds node execution details on the execution view

Gets the details in the tree view. This is the default view for details which fetch the node exeuction details and task executions on each node. 

1] Default is tree view and table format is not supported for this explicitly
```
flytectl get execution -p flytectldemo -d development f3a5a4034960f4aa1a09 --details

TABLE format is not supported on detailed view and defaults to tree view. Choose either json/yaml
Node Executions
└── start-node - SUCCEEDED - 1970-01-01 00:00:00 +0000 UTC - 1970-01-01 00:00:00 +0000 UTC
└── n1 - SUCCEEDED - 2021-06-30 08:51:07.3111846 +0000 UTC - 2021-06-30 08:51:17.192852 +0000 UTC
│   ├── Attempt :0
│       └── Task - SUCCEEDED - 1970-01-01 00:00:00 +0000 UTC - 1970-01-01 00:00:00 +0000 UTC
│       └── Task Type - 
│       └── Reason - 
│       └── Logs :
│           └── Name :Kubernetes Logs (User)
│           └── URI :http://localhost:30082/#/log/flytectldemo-development/f3a5a4034960f4aa1a09-n1-0/pod?namespace=flytectldemo-development
└── n0 - SUCCEEDED - 2021-06-30 08:49:01.582546 +0000 UTC - 2021-06-30 08:51:07.1850111 +0000 UTC
│   ├── Attempt :0
│       └── Task - SUCCEEDED - 1970-01-01 00:00:00 +0000 UTC - 1970-01-01 00:00:00 +0000 UTC
│       └── Task Type - 
│       └── Reason - 
│       └── Logs :
│           └── Name :Kubernetes Logs (User)
│           └── URI :http://localhost:30082/#/log/flytectldemo-development/f3a5a4034960f4aa1a09-n0-0/pod?namespace=flytectldemo-development
└── end-node - SUCCEEDED - 1970-01-01 00:00:00 +0000 UTC - 1970-01-01 00:00:00 +0000 UTC
```

2] Yaml  view for the details

```
flytectl get execution -p flytectldemo -d development f3a5a4034960f4aa1a09 --details  -o yaml
- closure:
    createdAt: "2021-06-30T08:51:17.271218200Z"
    phase: SUCCEEDED
    updatedAt: "2021-06-30T08:51:17.311695100Z"
  id:
    executionId:
      domain: development
      name: f3a5a4034960f4aa1a09
      project: flytectldemo
    nodeId: end-node
  inputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/end-node/data/inputs.pb
  metadata:
    specNodeId: end-node
- closure:
    createdAt: "2021-06-30T08:49:01.528398300Z"
    duration: 125.602465100s
    outputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n0/data/0/outputs.pb
    phase: SUCCEEDED
    startedAt: "2021-06-30T08:49:01.582546Z"
    updatedAt: "2021-06-30T08:51:07.185011100Z"
  id:
    executionId:
      domain: development
      name: f3a5a4034960f4aa1a09
      project: flytectldemo
    nodeId: n0
  inputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n0/data/inputs.pb
  metadata:
    specNodeId: n0
- closure:
    createdAt: "2021-06-30T08:51:07.249937800Z"
    duration: 9.881667400s
    outputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n1/data/0/outputs.pb
    phase: SUCCEEDED
    startedAt: "2021-06-30T08:51:07.311184600Z"
    updatedAt: "2021-06-30T08:51:17.192852400Z"
  id:
    executionId:
      domain: development
      name: f3a5a4034960f4aa1a09
      project: flytectldemo
    nodeId: n1
  inputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n1/data/inputs.pb
  metadata:
    specNodeId: n1
- closure:
    createdAt: "2021-06-30T08:49:01.491365700Z"
    phase: SUCCEEDED
    updatedAt: "2021-06-30T08:49:01.491365700Z"
  id:
    executionId:
      domain: development
      name: f3a5a4034960f4aa1a09
      project: flytectldemo
    nodeId: start-node
  inputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/start-node/data/inputs.pb
  metadata:
    specNodeId: start-node
```
3] Default tree view for task executions in a node provide a name of the node.

```
flytectl get execution -p flytectldemo -d development f3a5a4034960f4aa1a09 --details  --nodeId n0
TABLE format is not supported on detailed view and defaults to tree view. Choose either json/yaml
Task Executions
└── Attempt :0
    └── Task - SUCCEEDED - 1970-01-01 00:00:00 +0000 UTC - 1970-01-01 00:00:00 +0000 UTC
    └── Task Type - 
    └── Reason - 
    └── Logs :
        └── Name :Kubernetes Logs (User)
        └── URI :http://localhost:30082/#/log/flytectldemo-development/f3a5a4034960f4aa1a09-n0-0/pod?namespace=flytectldemo-development
```
4] Yaml representation for the same task executions.

```
flytectl get execution -p flytectldemo -d development f3a5a4034960f4aa1a09 --details  --nodeId n0 -o yaml
closure:
  createdAt: "2021-06-30T08:49:01.573698800Z"
  logs:
  - messageFormat: JSON
    name: Kubernetes Logs (User)
    uri: http://localhost:30082/#/log/flytectldemo-development/f3a5a4034960f4aa1a09-n0-0/pod?namespace=flytectldemo-development
  outputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n0/data/0/outputs.pb
  phase: SUCCEEDED
  updatedAt: "2021-06-30T08:51:07.169958100Z"
id:
  nodeExecutionId:
    executionId:
      domain: development
      name: f3a5a4034960f4aa1a09
      project: flytectldemo
    nodeId: n0
  taskId:
    domain: development
    name: core.control_flow.subworkflows.t1
    project: flytectldemo
    resourceType: TASK
    version: v3
inputUri: s3://my-s3-bucket/metadata/propeller/flytectldemo-development-f3a5a4034960f4aa1a09/n0/data/inputs.pb
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1124

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
