### PR TITLE
Sandbox status & Bash completion

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -29,13 +29,13 @@ var completionCmd = &cobra.Command{
 
 Bash:
 
-  $ source <(yourprogram completion bash)
+  $ source <(flytectl completion bash)
 
   # To load completions for each session, execute once:
   # Linux:
-  $ yourprogram completion bash > /etc/bash_completion.d/yourprogram
+  $ flytectl completion bash > /etc/bash_completion.d/flytectl
   # macOS:
-  $ yourprogram completion bash > /usr/local/etc/bash_completion.d/yourprogram
+  $ flytectl completion bash > /usr/local/etc/bash_completion.d/flytectl
 
 Zsh:
 
@@ -45,23 +45,23 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # To load completions for each session, execute once:
-  $ yourprogram completion zsh > "${fpath[1]}/_yourprogram"
+  $ flytectl completion zsh > "${fpath[1]}/_flytectl"
 
   # You will need to start a new shell for this setup to take effect.
 
 fish:
 
-  $ yourprogram completion fish | source
+  $ flytectl completion fish | source
 
   # To load completions for each session, execute once:
-  $ yourprogram completion fish > ~/.config/fish/completions/yourprogram.fish
+  $ flytectl completion fish > ~/.config/fish/completions/flytectl.fish
 
 PowerShell:
 
-  PS> yourprogram completion powershell | Out-String | Invoke-Expression
+  PS> flytectl completion powershell | Out-String | Invoke-Expression
 
   # To load completions for every new session, run:
-  PS> yourprogram completion powershell > yourprogram.ps1
+  PS> flytectl completion powershell > flytectl.ps1
   # and source this file from your PowerShell profile.
 `,
 	DisableFlagsInUseLine: true,

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,83 @@
+/*
+Copyright © 2021 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// completionCmd represents the completion command
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+  $ source <(yourprogram completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ yourprogram completion bash > /etc/bash_completion.d/yourprogram
+  # macOS:
+  $ yourprogram completion bash > /usr/local/etc/bash_completion.d/yourprogram
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it.  You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ yourprogram completion zsh > "${fpath[1]}/_yourprogram"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ yourprogram completion fish | source
+
+  # To load completions for each session, execute once:
+  $ yourprogram completion fish > ~/.config/fish/completions/yourprogram.fish
+
+PowerShell:
+
+  PS> yourprogram completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> yourprogram completion powershell > yourprogram.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,7 @@ func newRootCmd() *cobra.Command {
 	rootCmd.AddCommand(register.RemoteRegisterCommand())
 	rootCmd.AddCommand(delete.RemoteDeleteCommand())
 	rootCmd.AddCommand(sandbox.CreateSandboxCommand())
+	rootCmd.AddCommand(completionCmd)
 	// Added version command
 	versioncmd := version.GetVersionCommand(rootCmd)
 	cmdCore.AddCommands(rootCmd, versioncmd)

--- a/cmd/sandbox/sandbox.go
+++ b/cmd/sandbox/sandbox.go
@@ -39,7 +39,7 @@ func CreateSandboxCommand() *cobra.Command {
 			Short: teardownShort,
 			Long:  teardownLong},
 		"status": {CmdFunc: sandboxClusterStatus, Aliases: []string{}, ProjectDomainNotRequired: true,
-			Short: startShort,
+			Short: statusShort,
 			Long:  statusLong},
 	}
 

--- a/cmd/sandbox/sandbox.go
+++ b/cmd/sandbox/sandbox.go
@@ -38,6 +38,9 @@ func CreateSandboxCommand() *cobra.Command {
 		"teardown": {CmdFunc: teardownSandboxCluster, Aliases: []string{}, ProjectDomainNotRequired: true,
 			Short: teardownShort,
 			Long:  teardownLong},
+		"status": {CmdFunc: sandboxClusterStatus, Aliases: []string{}, ProjectDomainNotRequired: true,
+			Short: teardownShort,
+			Long:  teardownLong},
 	}
 
 	cmdcore.AddCommands(sandbox, sandboxResourcesFuncs)

--- a/cmd/sandbox/sandbox.go
+++ b/cmd/sandbox/sandbox.go
@@ -39,8 +39,8 @@ func CreateSandboxCommand() *cobra.Command {
 			Short: teardownShort,
 			Long:  teardownLong},
 		"status": {CmdFunc: sandboxClusterStatus, Aliases: []string{}, ProjectDomainNotRequired: true,
-			Short: teardownShort,
-			Long:  teardownLong},
+			Short: startShort,
+			Long:  statusLong},
 	}
 
 	cmdcore.AddCommands(sandbox, sandboxResourcesFuncs)

--- a/cmd/sandbox/sandbox_test.go
+++ b/cmd/sandbox/sandbox_test.go
@@ -13,7 +13,7 @@ func TestCreateSandboxCommand(t *testing.T) {
 	assert.Equal(t, sandboxCommand.Use, "sandbox")
 	assert.Equal(t, sandboxCommand.Short, "Used for testing flyte sandbox.")
 	fmt.Println(sandboxCommand.Commands())
-	assert.Equal(t, len(sandboxCommand.Commands()), 2)
+	assert.Equal(t, len(sandboxCommand.Commands()), 3)
 	cmdNouns := sandboxCommand.Commands()
 	// Sort by Use value.
 	sort.Slice(cmdNouns, func(i, j int) bool {
@@ -24,8 +24,12 @@ func TestCreateSandboxCommand(t *testing.T) {
 	assert.Equal(t, cmdNouns[0].Short, startShort)
 	assert.Equal(t, cmdNouns[0].Long, startLong)
 
-	assert.Equal(t, cmdNouns[1].Use, "teardown")
-	assert.Equal(t, cmdNouns[1].Short, teardownShort)
-	assert.Equal(t, cmdNouns[1].Long, teardownLong)
+	assert.Equal(t, cmdNouns[1].Use, "status")
+	assert.Equal(t, cmdNouns[1].Short, statusShort)
+	assert.Equal(t, cmdNouns[1].Long, statusLong)
+
+	assert.Equal(t, cmdNouns[2].Use, "teardown")
+	assert.Equal(t, cmdNouns[2].Short, teardownShort)
+	assert.Equal(t, cmdNouns[2].Long, teardownLong)
 
 }

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -154,7 +154,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
 			{
-				ID: "FlyteSandboxClusterName",
+				ID: docker.FlyteSandboxClusterName,
 				Names: []string{
 					docker.FlyteSandboxClusterName,
 				},

--- a/cmd/sandbox/status.go
+++ b/cmd/sandbox/status.go
@@ -36,6 +36,7 @@ func printStatus(ctx context.Context, cli docker.Docker) error {
 	c := docker.GetSandbox(ctx, cli)
 	if c == nil {
 		fmt.Printf("%v no Sandbox found \n", emoji.StopSign)
+		return nil
 	}
 	fmt.Printf("Flyte local sandbox cluster container image [%s] with status [%s] is in state [%s]", c.Image, c.Status, c.State)
 	return nil

--- a/cmd/sandbox/status.go
+++ b/cmd/sandbox/status.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"github.com/enescakir/emoji"
+	cmdCore "github.com/flyteorg/flytectl/cmd/core"
+	"github.com/flyteorg/flytectl/pkg/docker"
+	"time"
+)
+
+const (
+	statusShort = "Get the status of the sandbox environment."
+	statusLong  = `
+Status will retrieve the status of the Sandbox environment. Currently FlyteSandbox runs as a local docker container.
+This will return the docker status for this container
+
+Usage
+::
+
+ bin/flytectl sandbox status 
+
+`
+)
+
+func sandboxClusterStatus(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
+	cli, err := docker.GetDockerClient()
+	if err != nil {
+		return err
+	}
+
+	return printStatus(ctx, cli)
+}
+
+func printStatus(ctx context.Context, cli docker.Docker) error {
+	c := docker.GetSandbox(ctx, cli)
+	if c == nil {
+		fmt.Printf("%v no Sandbox found \n", emoji.StopSign)
+	}
+	fmt.Printf("Flyte local sandbox cluster container image [%s] started at [%s] is in status [%s]", c.Image, time.Unix(c.Created, 0).String(), c.Status)
+	return nil
+}

--- a/cmd/sandbox/status.go
+++ b/cmd/sandbox/status.go
@@ -3,10 +3,10 @@ package sandbox
 import (
 	"context"
 	"fmt"
+
 	"github.com/enescakir/emoji"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/docker"
-	"time"
 )
 
 const (
@@ -37,6 +37,6 @@ func printStatus(ctx context.Context, cli docker.Docker) error {
 	if c == nil {
 		fmt.Printf("%v no Sandbox found \n", emoji.StopSign)
 	}
-	fmt.Printf("Flyte local sandbox cluster container image [%s] started at [%s] is in status [%s]", c.Image, time.Unix(c.Created, 0).String(), c.Status)
+	fmt.Printf("Flyte local sandbox cluster container image [%s] with status [%s] is in state [%s]", c.Image, c.Status, c.State)
 	return nil
 }

--- a/cmd/sandbox/status_test.go
+++ b/cmd/sandbox/status_test.go
@@ -1,0 +1,43 @@
+package sandbox
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	cmdCore "github.com/flyteorg/flytectl/cmd/core"
+	"github.com/flyteorg/flytectl/pkg/docker"
+	"github.com/flyteorg/flytectl/pkg/docker/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSandboxStatus(t *testing.T) {
+	t.Run("Sandbox status with zero result", func(t *testing.T) {
+		ctx := context.Background()
+		mockOutStream := new(io.Writer)
+		cmdCtx := cmdCore.NewCommandContext(nil, *mockOutStream)
+		mockDocker := &mocks.Docker{}
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		docker.Client = mockDocker
+		err := sandboxClusterStatus(ctx, []string{}, cmdCtx)
+		assert.Nil(t, err)
+	})
+	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
+		ctx := context.Background()
+		mockOutStream := new(io.Writer)
+		cmdCtx := cmdCore.NewCommandContext(nil, *mockOutStream)
+		mockDocker := &mocks.Docker{}
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+			{
+				ID: docker.FlyteSandboxClusterName,
+				Names: []string{
+					docker.FlyteSandboxClusterName,
+				},
+			},
+		}, nil)
+		docker.Client = mockDocker
+		err := sandboxClusterStatus(ctx, []string{}, cmdCtx)
+		assert.Nil(t, err)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.3.0
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23
 	github.com/kr/text v0.2.0 // indirect
 	github.com/landoop/tableprinter v0.0.0-20180806200924-8bd8c2576d27
@@ -25,7 +25,7 @@ require (
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
 	github.com/sirupsen/logrus v1.8.0
 	github.com/spf13/cobra v1.1.3


### PR DESCRIPTION
# TL;DR
Usage:
`flytectl sandbox status`
Returns the status of Sandbox container, if it is running

and

`flytectl completion [bash|zsh...]`
returns a completion file for various shells, which help in auto-complete

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue




