### PR TITLE
Rename flytesnacks flag to sourcesPath

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,6 @@ PACKAGE ?=github.com/flyteorg/flytestdlib
 
 LD_FLAGS="-s -w -X $(PACKAGE)/version.Version=$(GIT_VERSION) -X $(PACKAGE)/version.Build=$(GIT_HASH) -X $(PACKAGE)/version.BuildTime=$(TIMESTAMP)"
 
-
-
 define PIP_COMPILE
 pip-compile $(1) --upgrade --verbose
 endef

--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -50,6 +50,6 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
-	cmdFlags.StringVar(&DefaultConfig.SnacksRepo, fmt.Sprintf("%v%v", prefix, "flytesnacks"), DefaultConfig.SnacksRepo, " Path of your flytesnacks repository")
+	cmdFlags.StringVar(&DefaultConfig.SourcesPath, fmt.Sprintf("%v%v", prefix, "flytesnacks"), DefaultConfig.SourcesPath, " Path of your flytesnacks repository")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -106,7 +106,7 @@ func TestConfig_SetFlags(t *testing.T) {
 
 			cmdFlags.Set("flytesnacks", testValue)
 			if vString, err := cmdFlags.GetString("flytesnacks"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.SnacksRepo)
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.SourcesPath)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -5,7 +5,7 @@ var (
 	DefaultConfig = &Config{}
 )
 
-// Config
+// Config represents the config parameters exposed for the `sandbox` command.
 type Config struct {
-	SnacksRepo string `json:"flytesnacks" pflag:", Path of your flytesnacks repository"`
+	SourcesPath string `json:"sourcesPath" pflag:",Path to your source code path where flyte workflows and tasks are."`
 }

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -26,7 +26,7 @@ Start will run the flyte sandbox cluster inside a docker container and setup the
 Mount your flytesnacks repository code inside sandbox 
 ::
 
- bin/flytectl sandbox start --flytesnacks=$HOME/flyteorg/flytesnacks 
+ bin/flytectl sandbox start --sourcesPath=$HOME/flyteorg/flytesnacks 
 Usage
 	`
 )
@@ -65,10 +65,10 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 		return nil, err
 	}
 
-	if len(sandboxConfig.DefaultConfig.SnacksRepo) > 0 {
+	if len(sandboxConfig.DefaultConfig.SourcesPath) > 0 {
 		docker.Volumes = append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 	}

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -61,10 +61,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -97,10 +97,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -133,10 +133,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -177,10 +177,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -213,10 +213,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -249,10 +249,10 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		sandboxConfig.DefaultConfig.SnacksRepo = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.SourcesPath = f.UserHomeDir()
 		volumes := append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.SnacksRepo,
+			Source: sandboxConfig.DefaultConfig.SourcesPath,
 			Target: docker.FlyteSnackDir,
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -312,7 +312,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		}).Return(reader, nil)
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		docker.Client = mockDocker
-		sandboxConfig.DefaultConfig.SnacksRepo = ""
+		sandboxConfig.DefaultConfig.SourcesPath = ""
 		err := startSandboxCluster(ctx, []string{}, cmdCtx)
 		assert.Nil(t, err)
 	})
@@ -348,7 +348,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		}).Return(reader, nil)
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		docker.Client = mockDocker
-		sandboxConfig.DefaultConfig.SnacksRepo = ""
+		sandboxConfig.DefaultConfig.SourcesPath = ""
 		err := startSandboxCluster(ctx, []string{}, cmdCtx)
 		assert.NotNil(t, err)
 	})

--- a/docs/source/gen/flytectl_sandbox_start.rst
+++ b/docs/source/gen/flytectl_sandbox_start.rst
@@ -18,7 +18,7 @@ Start will run the flyte sandbox cluster inside a docker container and setup the
 Mount your flytesnacks repository code inside sandbox 
 ::
 
- bin/flytectl sandbox start --flytesnacks=$HOME/flyteorg/flytesnacks 
+ bin/flytectl sandbox start --sourcesPath=$HOME/flyteorg/flytesnacks
 Usage
 	
 
@@ -31,7 +31,7 @@ Options
 
 ::
 
-      --flytesnacks string    Path of your flytesnacks repository
+      --sourcesPath string   Path to your source code path where flyte workflows and tasks are.
   -h, --help                 help for start
 
 Options inherited from parent commands


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Rename `flytectl sandbox --flytesnacks=<>` to `flytectl sandbox --sourcesPath=<>` since it can be generalized to any flyte-repo/directory

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue
