### PR TITLE
Relative path for Source dir

### DIFF
--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/flyteorg/flytectl/pkg/docker"
 
@@ -67,19 +68,25 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	}
 
 	if len(sandboxConfig.DefaultConfig.Source) > 0 {
+		source, err := filepath.Abs(sandboxConfig.DefaultConfig.Source)
+		if err != nil {
+			return nil, err
+		}
 		docker.Volumes = append(docker.Volumes, mount.Mount{
 			Type:   mount.TypeBind,
-			Source: sandboxConfig.DefaultConfig.Source,
+			Source: source,
 			Target: docker.FlyteSnackDir,
 		})
 	}
 
+	fmt.Printf("%v pulling docker image %s\n", emoji.Whale, docker.ImageName)
 	os.Setenv("KUBECONFIG", docker.Kubeconfig)
 	os.Setenv("FLYTECTL_CONFIG", docker.FlytectlConfig)
 	if err := docker.PullDockerImage(ctx, cli, docker.ImageName); err != nil {
 		return nil, err
 	}
 
+	fmt.Printf("%v booting Flyte-sandbox container\n", emoji.FactoryWorker)
 	exposedPorts, portBindings, _ := docker.GetSandboxPorts()
 	ID, err := docker.StartContainer(ctx, cli, docker.Volumes, exposedPorts, portBindings, docker.FlyteSandboxClusterName, docker.ImageName)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Adds support for relative paths `flytectl sandbox start --source .`.
Flytectl will convert this to an absolute path before passing it to Docker,

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


