### PR TITLE
Graphviz does not like hyphens #patch

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -339,8 +339,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.19.8 h1:jWWIEnFMgJCZm/XK25Xts4+kQhoOrd5dWgLj/fLsbIg=
-github.com/flyteorg/flyteidl v0.19.8/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flyteidl v0.19.9 h1:1j4/YbV/G1m2hrK017F9K0JYZYxCCwf4qtEkiNnUiEw=
 github.com/flyteorg/flyteidl v0.19.9/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=

--- a/pkg/visualize/graphviz.go
+++ b/pkg/visualize/graphviz.go
@@ -229,7 +229,8 @@ func (gb *graphBuilder) constructNode(parentGraphName string, prefix string, gra
 			}
 			gb.nodeClusters[name] = parentGraphName
 		case *core.Node_BranchNode:
-			branchSubGraphName := SubgraphPrefix + n.Metadata.Name
+			sanitizedName := strings.ReplaceAll(n.Metadata.Name, "-", "_")
+			branchSubGraphName := SubgraphPrefix + sanitizedName
 			err := graph.AddSubGraph(parentGraphName, branchSubGraphName, nil)
 			if err != nil {
 				return nil, err
@@ -247,7 +248,8 @@ func (gb *graphBuilder) constructNode(parentGraphName string, prefix string, gra
 					return nil, err
 				}
 			} else {
-				subGraphName := SubgraphPrefix + name
+				sanitizedName := strings.ReplaceAll(name, "-", "_")
+				subGraphName := SubgraphPrefix + sanitizedName
 				err := graph.AddSubGraph(parentGraphName, subGraphName, nil)
 				if err != nil {
 					return nil, err

--- a/pkg/visualize/graphviz.go
+++ b/pkg/visualize/graphviz.go
@@ -231,7 +231,7 @@ func (gb *graphBuilder) constructNode(parentGraphName string, prefix string, gra
 		case *core.Node_BranchNode:
 			sanitizedName := strings.ReplaceAll(n.Metadata.Name, "-", "_")
 			branchSubGraphName := SubgraphPrefix + sanitizedName
-			err := graph.AddSubGraph(parentGraphName, branchSubGraphName, nil)
+			err := graph.AddSubGraph(parentGraphName, branchSubGraphName, map[string]string{LabelAttr: sanitizedName})
 			if err != nil {
 				return nil, err
 			}
@@ -250,7 +250,7 @@ func (gb *graphBuilder) constructNode(parentGraphName string, prefix string, gra
 			} else {
 				sanitizedName := strings.ReplaceAll(name, "-", "_")
 				subGraphName := SubgraphPrefix + sanitizedName
-				err := graph.AddSubGraph(parentGraphName, subGraphName, nil)
+				err := graph.AddSubGraph(parentGraphName, subGraphName, map[string]string{LabelAttr: sanitizedName})
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
# TL;DR
Some graphs that have nested conditionals can have node names that use hyphens. This PR makes it so that hyphens in cluster name are also replaced with `_`

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [x] Any pending items have an associated Issue

