### PR TITLE
Bug fix in sandbox start when sandbox exist

### DIFF
--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -14,4 +14,6 @@ var (
 
 	ErrTaskNotPassed    = "Task name not passed\n" // #nosec
 	ErrFailedTaskUpdate = "Task %v failed to get updated to due to %v\n"
+
+	ErrSandboxExists = "Sandbox Exist\n"
 )

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -71,11 +71,7 @@ func startSandboxCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comm
 
 	reader, err := startSandbox(ctx, cli, os.Stdin)
 	if err != nil {
-		if err.Error() != clierrors.ErrSandboxExists {
-			return err
-		}
-		printExistingSandboxMessage()
-		return nil
+		return err
 	}
 	if reader != nil {
 		docker.WaitForSandbox(reader, docker.SuccessMessage)
@@ -87,7 +83,11 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	fmt.Printf("%v Bootstrapping a brand new flyte cluster... %v %v\n", emoji.FactoryWorker, emoji.Hammer, emoji.Wrench)
 
 	if err := docker.RemoveSandbox(ctx, cli, reader); err != nil {
-		return nil, err
+		if err.Error() != clierrors.ErrSandboxExists {
+			return nil, err
+		}
+		printExistingSandboxMessage()
+		return nil, nil
 	}
 
 	if err := util.SetupFlyteDir(); err != nil {

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
+
+	"github.com/flyteorg/flytectl/clierrors"
 
 	"github.com/docker/docker/api/types/mount"
 
@@ -68,7 +71,11 @@ func startSandboxCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comm
 
 	reader, err := startSandbox(ctx, cli, os.Stdin)
 	if err != nil {
-		return err
+		if err.Error() != clierrors.ErrSandboxExists {
+			return err
+		}
+		printExistingSandboxMessage()
+		return nil
 	}
 	if reader != nil {
 		docker.WaitForSandbox(reader, docker.SuccessMessage)
@@ -80,9 +87,6 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	fmt.Printf("%v Bootstrapping a brand new flyte cluster... %v %v\n", emoji.FactoryWorker, emoji.Hammer, emoji.Wrench)
 
 	if err := docker.RemoveSandbox(ctx, cli, reader); err != nil {
-		if err.Error() == "EXIST" {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -176,4 +180,18 @@ func downloadFlyteManifest(version string) error {
 		return err
 	}
 	return nil
+}
+
+func printExistingSandboxMessage() {
+	kubeconfig := strings.Join([]string{
+		"$KUBECONFIG",
+		f.FilePathJoin(f.UserHomeDir(), ".kube", "config"),
+		docker.Kubeconfig,
+	}, ":")
+
+	fmt.Printf("Existing details of your sandbox:")
+	fmt.Printf("%v %v %v %v %v \n", emoji.ManTechnologist, docker.SuccessMessage, emoji.Rocket, emoji.Rocket, emoji.PartyPopper)
+	fmt.Printf("Add KUBECONFIG and FLYTECTL_CONFIG to your environment variable \n")
+	fmt.Printf("export KUBECONFIG=%v \n", kubeconfig)
+	fmt.Printf("export FLYTECTL_CONFIG=%v \n", configutil.FlytectlConfig)
 }

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -70,7 +70,9 @@ func startSandboxCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comm
 	if err != nil {
 		return err
 	}
-	docker.WaitForSandbox(reader, docker.SuccessMessage)
+	if reader != nil {
+		docker.WaitForSandbox(reader, docker.SuccessMessage)
+	}
 	return nil
 }
 
@@ -78,6 +80,9 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	fmt.Printf("%v Bootstrapping a brand new flyte cluster... %v %v\n", emoji.FactoryWorker, emoji.Hammer, emoji.Wrench)
 
 	if err := docker.RemoveSandbox(ctx, cli, reader); err != nil {
+		if err.Error() == "EXIST" {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/flyteorg/flytectl/clierrors"
+
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 
 	sandboxConfig "github.com/flyteorg/flytectl/cmd/config/subcommand/sandbox"
@@ -91,8 +93,10 @@ func TestStartSandboxFunc(t *testing.T) {
 			Follow:     true,
 		}).Return(nil, nil)
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
-		_, err := startSandbox(ctx, mockDocker, strings.NewReader("n"))
-		assert.Nil(t, err)
+		reader, err := startSandbox(ctx, mockDocker, strings.NewReader("n"))
+		assert.NotNil(t, err)
+		assert.Equal(t, err.Error(), clierrors.ErrSandboxExists)
+		assert.Nil(t, reader)
 	})
 	t.Run("Successfully run sandbox cluster with source code", func(t *testing.T) {
 		ctx := context.Background()

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -57,6 +57,43 @@ func TestStartSandboxFunc(t *testing.T) {
 		_, err := startSandbox(ctx, mockDocker, os.Stdin)
 		assert.Nil(t, err)
 	})
+	t.Run("Successfully exit when sandbox cluster exist", func(t *testing.T) {
+		ctx := context.Background()
+		mockDocker := &mocks.Docker{}
+		errCh := make(chan error)
+		bodyStatus := make(chan container.ContainerWaitOKBody)
+		mockDocker.OnContainerCreate(ctx, &container.Config{
+			Env:          docker.Environment,
+			Image:        docker.ImageName,
+			Tty:          false,
+			ExposedPorts: p1,
+		}, &container.HostConfig{
+			Mounts:       docker.Volumes,
+			PortBindings: p2,
+			Privileged:   true,
+		}, nil, nil, mock.Anything).Return(container.ContainerCreateCreatedBody{
+			ID: "Hello",
+		}, nil)
+		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+			{
+				ID: docker.FlyteSandboxClusterName,
+				Names: []string{
+					docker.FlyteSandboxClusterName,
+				},
+			},
+		}, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
+			ShowStderr: true,
+			ShowStdout: true,
+			Timestamps: true,
+			Follow:     true,
+		}).Return(nil, nil)
+		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
+		_, err := startSandbox(ctx, mockDocker, strings.NewReader("n"))
+		assert.Nil(t, err)
+	})
 	t.Run("Successfully run sandbox cluster with source code", func(t *testing.T) {
 		ctx := context.Background()
 		errCh := make(chan error)

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/flyteorg/flytectl/clierrors"
-
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 
 	sandboxConfig "github.com/flyteorg/flytectl/cmd/config/subcommand/sandbox"
@@ -94,8 +92,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		}).Return(nil, nil)
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		reader, err := startSandbox(ctx, mockDocker, strings.NewReader("n"))
-		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), clierrors.ErrSandboxExists)
+		assert.Nil(t, err)
 		assert.Nil(t, reader)
 	})
 	t.Run("Successfully run sandbox cluster with source code", func(t *testing.T) {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ golang
 
     .. prompt:: bash $
 
-       brew upgrade flytectl
+       brew update && brew upgrade flytectl
 
   .. tab:: Other Operating systems
 

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -69,7 +69,7 @@ func RemoveSandbox(ctx context.Context, cli Docker, reader io.Reader) error {
 			})
 			return err
 		}
-		return nil
+		return fmt.Errorf("EXIST")
 	}
 	return nil
 }

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -3,10 +3,13 @@ package docker
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	"github.com/flyteorg/flytectl/clierrors"
 
 	"github.com/flyteorg/flytectl/pkg/configutil"
 
@@ -69,7 +72,7 @@ func RemoveSandbox(ctx context.Context, cli Docker, reader io.Reader) error {
 			})
 			return err
 		}
-		return fmt.Errorf("EXIST")
+		return errors.New(clierrors.ErrSandboxExists)
 	}
 	return nil
 }

--- a/pkg/docker/docker_util_test.go
+++ b/pkg/docker/docker_util_test.go
@@ -80,7 +80,7 @@ func TestRemoveSandboxWithNoReply(t *testing.T) {
 		mockDocker.OnContainerList(context, types.ContainerListOptions{All: true}).Return(containers, nil)
 		mockDocker.OnContainerRemove(context, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
 		err := RemoveSandbox(context, mockDocker, strings.NewReader("n"))
-		assert.Nil(t, err)
+		assert.NotNil(t, err)
 	})
 
 	t.Run("Successfully remove sandbox container with zero sandbox containers are running", func(t *testing.T) {


### PR DESCRIPTION
# TL;DR
- Bugfix in sandbox start when sandbox exists.  (Before fix if you say no on the existing cluster then ideally it should return exit code 0 but it will continue sandbox start process that was wrong)
- update upgrade in docs

```bash
$ flytectl sandbox start 
delete existing sandbox cluster [y/n]: n
```


## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
