### PR TITLE
Fix config init command fails if no flyte dir doesn't exist

### DIFF
--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/flyteorg/flytectl/pkg/util"
+
 	"github.com/flyteorg/flytestdlib/logger"
 
 	"github.com/flyteorg/flytectl/pkg/configutil"
@@ -68,6 +70,10 @@ func configInitFunc(ctx context.Context, args []string, cmdCtx cmdcore.CommandCo
 }
 
 func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
+
+	if err := util.SetupFlyteDir(); err != nil {
+		return err
+	}
 
 	templateValues := configutil.ConfigTemplateSpec{
 		Host:     "dns:///localhost:30081",

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/flyteorg/flytectl/pkg/util"
-
 	"github.com/flyteorg/flytestdlib/logger"
+
+	"github.com/flyteorg/flytectl/pkg/util"
 
 	"github.com/flyteorg/flytectl/pkg/configutil"
 
@@ -93,6 +93,8 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 			if strings.ToUpper(result) == "GCS" {
 				templateStr = configutil.GetGoogleCloudTemplate()
 			}
+		} else {
+			logger.Infof(ctx, "Init flytectl config for remote cluster, Please update your storage config in %s. Learn more about the config here https://docs.flyte.org/projects/flytectl/en/latest/index.html#configure", configutil.ConfigFile)
 		}
 	}
 	var _err error
@@ -106,9 +108,9 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 			_err = configutil.SetupConfig(configutil.ConfigFile, templateStr, templateValues)
 		}
 	}
-
-	if len(initConfig.DefaultConfig.Host) > 0 {
-		logger.Infof(ctx, "Init flytectl config for remote cluster, Please update your storage config in %s. Learn more about the config here https://docs.flyte.org/projects/flytectl/en/latest/index.html#configure", configutil.ConfigFile)
+	if _err != nil {
+		return _err
 	}
-	return _err
+	fmt.Printf("Init flytectl config file at [%s]", configutil.ConfigFile)
+	return nil
 }


### PR DESCRIPTION
# TL;DR
- Currently, config init fails if flyte dir doesn't exist 

Current error: 
```
❯ flytectl config init 
INFO[0000] [0] Couldn't find a config file []. Relying on env vars and pflags. 
{"json":{},"level":"warning","msg":"Starting an unauthenticated client because: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"","ts":"2021-07-16T14:27:46+01:00"}
{"json":{},"level":"info","msg":"Initialized Admin client","ts":"2021-07-16T14:27:46+01:00"}
Error: open /Users/yuvraj/.flyte/config.yaml: no such file or directory
{"json":{},"level":"error","msg":"open /Users/yuvraj/.flyte/config.yaml: no such file or directory","ts":"2021-07-16T14:27:46+01:00"}

```

After fix 
```
❯ flytectl config init 
INFO[0000] [0] Couldn't find a config file []. Relying on env vars and pflags. 
{"json":{},"level":"warning","msg":"Starting an unauthenticated client because: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"","ts":"2021-07-16T14:27:46+01:00"}
{"json":{},"level":"info","msg":"Initialized Admin client","ts":"2021-07-16T14:27:46+01:00"}
```
## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1249

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
