### PR TITLE
Render descriptions in flytectl

### DIFF
--- a/cmd/get/execution_util.go
+++ b/cmd/get/execution_util.go
@@ -3,6 +3,7 @@ package get
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
 
@@ -10,21 +11,19 @@ import (
 	"github.com/flyteorg/flyteidl/clients/go/coreutils"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-
-	"sigs.k8s.io/yaml"
 )
 
-// ExecutionConfig is duplicated struct from create with the same structure. This is to avoid the circular dependency.
+// ExecutionConfig is duplicated struct from create with the same structure. This is to avoid the circular dependency. Only works with go-yaml.
 // TODO : replace this with a cleaner design
 type ExecutionConfig struct {
-	TargetDomain    string                 `json:"targetDomain"`
-	TargetProject   string                 `json:"targetProject"`
-	KubeServiceAcct string                 `json:"kubeServiceAcct"`
-	IamRoleARN      string                 `json:"iamRoleARN"`
-	Workflow        string                 `json:"workflow,omitempty"`
-	Task            string                 `json:"task,omitempty"`
-	Version         string                 `json:"version"`
-	Inputs          map[string]interface{} `json:"inputs"`
+	IamRoleARN      string               `yaml:"iamRoleARN"`
+	Inputs          map[string]yaml.Node `yaml:"inputs"`
+	KubeServiceAcct string               `yaml:"kubeServiceAcct"`
+	TargetDomain    string               `yaml:"targetDomain"`
+	TargetProject   string               `yaml:"targetProject"`
+	Task            string               `yaml:"task,omitempty"`
+	Version         string               `yaml:"version"`
+	Workflow        string               `yaml:"workflow,omitempty"`
 }
 
 func WriteExecConfigToFile(executionConfig ExecutionConfig, fileName string) error {
@@ -78,16 +77,27 @@ func TaskInputs(task *admin.Task) map[string]*core.Variable {
 	return task.Closure.CompiledTask.Template.Interface.Inputs.Variables
 }
 
-func ParamMapForTask(task *admin.Task) (map[string]interface{}, error) {
+func ParamMapForTask(task *admin.Task) (map[string]yaml.Node, error) {
 	taskInputs := TaskInputs(task)
-	paramMap := make(map[string]interface{}, len(taskInputs))
+	paramMap := make(map[string]yaml.Node, len(taskInputs))
 	for k, v := range taskInputs {
 		varTypeValue, err := coreutils.MakeDefaultLiteralForType(v.Type)
 		if err != nil {
 			fmt.Println("error creating default value for literal type ", v.Type)
 			return nil, err
 		}
-		if paramMap[k], err = coreutils.ExtractFromLiteral(varTypeValue); err != nil {
+		var nativeLiteral interface{}
+		if nativeLiteral, err = coreutils.ExtractFromLiteral(varTypeValue); err != nil {
+			return nil, err
+		}
+
+		if k == v.Description {
+			// a: # a isn't very helpful
+			paramMap[k], err = getCommentedYamlNode(nativeLiteral, "")
+		} else {
+			paramMap[k], err = getCommentedYamlNode(nativeLiteral, v.Description)
+		}
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -105,24 +115,42 @@ func WorkflowParams(lp *admin.LaunchPlan) map[string]*core.Parameter {
 	return lp.Spec.DefaultInputs.Parameters
 }
 
-func ParamMapForWorkflow(lp *admin.LaunchPlan) (map[string]interface{}, error) {
+func ParamMapForWorkflow(lp *admin.LaunchPlan) (map[string]yaml.Node, error) {
 	workflowParams := WorkflowParams(lp)
-	paramMap := make(map[string]interface{}, len(workflowParams))
+	paramMap := make(map[string]yaml.Node, len(workflowParams))
 	for k, v := range workflowParams {
 		varTypeValue, err := coreutils.MakeDefaultLiteralForType(v.Var.Type)
 		if err != nil {
 			fmt.Println("error creating default value for literal type ", v.Var.Type)
 			return nil, err
 		}
-		if paramMap[k], err = coreutils.ExtractFromLiteral(varTypeValue); err != nil {
+		var nativeLiteral interface{}
+		if nativeLiteral, err = coreutils.ExtractFromLiteral(varTypeValue); err != nil {
 			return nil, err
 		}
 		// Override if there is a default value
 		if paramsDefault, ok := v.Behavior.(*core.Parameter_Default); ok {
-			if paramMap[k], err = coreutils.ExtractFromLiteral(paramsDefault.Default); err != nil {
+			if nativeLiteral, err = coreutils.ExtractFromLiteral(paramsDefault.Default); err != nil {
 				return nil, err
 			}
 		}
+		if k == v.Var.Description {
+			// a: # a isn't very helpful
+			paramMap[k], err = getCommentedYamlNode(nativeLiteral, "")
+		} else {
+			paramMap[k], err = getCommentedYamlNode(nativeLiteral, v.Var.Description)
+		}
+
+		if err != nil {
+			return nil, err
+		}
 	}
 	return paramMap, nil
+}
+
+func getCommentedYamlNode(input interface{}, comment string) (yaml.Node, error) {
+	var node yaml.Node
+	err := node.Encode(input)
+	node.LineComment = comment
+	return node, err
 }

--- a/cmd/get/execution_util.go
+++ b/cmd/get/execution_util.go
@@ -3,9 +3,10 @@ package get
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"
+
+	"gopkg.in/yaml.v3"
 
 	cmdUtil "github.com/flyteorg/flytectl/pkg/commandutils"
 	"github.com/flyteorg/flyteidl/clients/go/coreutils"

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -127,6 +127,7 @@ func LaunchplanToProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 func LaunchplanToTableProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 	messages := make([]proto.Message, 0, len(l))
 	for _, m := range l {
+		m := proto.Clone(m).(*admin.LaunchPlan)
 		if m.Closure.ExpectedInputs != nil {
 			printer.FormatParameterDescriptions(m.Closure.ExpectedInputs.Parameters)
 		}

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -101,7 +101,7 @@ Usage
 var launchplanColumns = []printer.Column{
 	{Header: "Version", JSONPath: "$.id.version"},
 	{Header: "Name", JSONPath: "$.id.name"},
-	{Header: "Type", JSONPath: "$.id.resourceType"},
+	{Header: "Type", JSONPath: "$.closure.compiledTask.template.type"},
 	{Header: "State", JSONPath: "$.spec.state"},
 	{Header: "Schedule", JSONPath: "$.spec.entityMetadata.schedule"},
 	{Header: "Inputs", JSONPath: "$.closure.expectedInputs.parameters." + printer.DefaultFormattedDescriptionsKey + ".var.description"},

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -101,9 +101,11 @@ Usage
 var launchplanColumns = []printer.Column{
 	{Header: "Version", JSONPath: "$.id.version"},
 	{Header: "Name", JSONPath: "$.id.name"},
-	{Header: "Type", JSONPath: "$.closure.compiledTask.template.type"},
+	{Header: "Type", JSONPath: "$.id.resourceType"},
 	{Header: "State", JSONPath: "$.spec.state"},
 	{Header: "Schedule", JSONPath: "$.spec.entityMetadata.schedule"},
+	{Header: "Inputs", JSONPath: "$.closure.expectedInputs.parameters." + printer.DefaultFormattedDescriptionsKey + ".var.description"},
+	{Header: "Outputs", JSONPath: "$.closure.expectedOutputs.variables." + printer.DefaultFormattedDescriptionsKey + ".description"},
 }
 
 // Column structure for get all launchplans
@@ -122,6 +124,20 @@ func LaunchplanToProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 	return messages
 }
 
+func LaunchplanToTableProtoMessages(l []*admin.LaunchPlan) []proto.Message {
+	messages := make([]proto.Message, 0, len(l))
+	for _, m := range l {
+		if m.Closure.ExpectedInputs != nil {
+			printer.FormatParameterDescriptions(m.Closure.ExpectedInputs.Parameters)
+		}
+		if m.Closure.ExpectedOutputs != nil {
+			printer.FormatVariableDescriptions(m.Closure.ExpectedOutputs.Variables)
+		}
+		messages = append(messages, m)
+	}
+	return messages
+}
+
 func getLaunchPlanFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
 	launchPlanPrinter := printer.Printer{}
 	var launchPlans []*admin.LaunchPlan
@@ -134,8 +150,13 @@ func getLaunchPlanFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 			return err
 		}
 		logger.Debugf(ctx, "Retrieved %v launch plans", len(launchPlans))
-		err = launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplanColumns,
-			LaunchplanToProtoMessages(launchPlans)...)
+		if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
+			err = launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplanColumns,
+				LaunchplanToTableProtoMessages(launchPlans)...)
+		} else {
+			err = launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplanColumns,
+				LaunchplanToProtoMessages(launchPlans)...)
+		}
 		if err != nil {
 			return err
 		}
@@ -148,8 +169,13 @@ func getLaunchPlanFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 	}
 
 	logger.Debugf(ctx, "Retrieved %v launch plans", len(launchPlans))
+	if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
+		return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplansColumns,
+			LaunchplanToTableProtoMessages(launchPlans)...)
+	}
 	return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplansColumns,
 		LaunchplanToProtoMessages(launchPlans)...)
+
 }
 
 // FetchLPForName fetches the launchplan give it name.

--- a/cmd/get/launch_plan_test.go
+++ b/cmd/get/launch_plan_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flyteorg/flytectl/pkg/filters"
 
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/launchplan"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	u "github.com/flyteorg/flytectl/cmd/testutils"
@@ -48,6 +49,7 @@ func getLaunchPlanSetup() {
 						},
 					},
 				},
+				Description: "short desc",
 			},
 		},
 		"numbers_count": {
@@ -57,6 +59,7 @@ func getLaunchPlanSetup() {
 						Simple: core.SimpleType_INTEGER,
 					},
 				},
+				Description: "long description will be truncated in table",
 			},
 		},
 		"run_local_at_count": {
@@ -66,6 +69,7 @@ func getLaunchPlanSetup() {
 						Simple: core.SimpleType_INTEGER,
 					},
 				},
+				Description: "run_local_at_count",
 			},
 			Behavior: &core.Parameter_Default{
 				Default: &core.Literal{
@@ -258,21 +262,24 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 								"collectionType": {
 									"simple": "INTEGER"
 								}
-							}
+							},
+							"description": "short desc"
 						}
 					},
 					"numbers_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "long description will be truncated in table"
 						}
 					},
 					"run_local_at_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "run_local_at_count"
 						},
 						"default": {
 							"scalar": {
@@ -294,21 +301,24 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 								"collectionType": {
 									"simple": "INTEGER"
 								}
-							}
+							},
+							"description": "short desc"
 						}
 					},
 					"numbers_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "long description will be truncated in table"
 						}
 					},
 					"run_local_at_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "run_local_at_count"
 						},
 						"default": {
 							"scalar": {
@@ -337,21 +347,24 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 								"collectionType": {
 									"simple": "INTEGER"
 								}
-							}
+							},
+							"description": "short desc"
 						}
 					},
 					"numbers_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "long description will be truncated in table"
 						}
 					},
 					"run_local_at_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "run_local_at_count"
 						},
 						"default": {
 							"scalar": {
@@ -373,21 +386,24 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 								"collectionType": {
 									"simple": "INTEGER"
 								}
-							}
+							},
+							"description": "short desc"
 						}
 					},
 					"numbers_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "long description will be truncated in table"
 						}
 					},
 					"run_local_at_count": {
 						"var": {
 							"type": {
 								"simple": "INTEGER"
-							}
+							},
+							"description": "run_local_at_count"
 						},
 						"default": {
 							"scalar": {
@@ -429,21 +445,24 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -465,21 +484,24 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -520,21 +542,24 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -556,21 +581,24 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -595,7 +623,7 @@ func TestGetLaunchPlans(t *testing.T) {
 	argsLp = []string{}
 	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 	assert.Nil(t, err)
-	tearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}}}},"numbers_count": {"var": {"type": {"simple": "INTEGER"}}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"}},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}}}},"numbers_count": {"var": {"type": {"simple": "INTEGER"}}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"}},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}}}},"numbers_count": {"var": {"type": {"simple": "INTEGER"}}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"}},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}}}},"numbers_count": {"var": {"type": {"simple": "INTEGER"}}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"}},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
+	tearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 }
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
@@ -624,21 +652,24 @@ func TestGetLaunchPlansWithExecFile(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -660,21 +691,24 @@ func TestGetLaunchPlansWithExecFile(t *testing.T) {
 							"collectionType": {
 								"simple": "INTEGER"
 							}
-						}
+						},
+						"description": "short desc"
 					}
 				},
 				"numbers_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "long description will be truncated in table"
 					}
 				},
 				"run_local_at_count": {
 					"var": {
 						"type": {
 							"simple": "INTEGER"
-						}
+						},
+						"description": "run_local_at_count"
 					},
 					"default": {
 						"scalar": {
@@ -689,4 +723,29 @@ func TestGetLaunchPlansWithExecFile(t *testing.T) {
 		"createdAt": "1970-01-01T00:00:01Z"
 	}
 }`)
+}
+
+func TestGetLaunchPlanTableFunc(t *testing.T) {
+	setup()
+	getLaunchPlanSetup()
+	mockClient.OnListLaunchPlansMatch(ctx, resourceGetRequest).Return(launchPlanListResponse, nil)
+	mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
+	mockClient.OnListLaunchPlanIdsMatch(ctx, namedIDRequest).Return(namedIdentifierList, nil)
+	config.GetConfig().Output = "table"
+	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
+	assert.Nil(t, err)
+	mockClient.AssertCalled(t, "ListLaunchPlans", ctx, resourceGetRequest)
+	tearDownAndVerify(t, `
+--------- ------------- ------ ------- ---------- --------------------------- --------- 
+| VERSION | NAME        | TYPE | STATE | SCHEDULE | INPUTS                    | OUTPUTS | 
+--------- ------------- ------ ------- ---------- --------------------------- --------- 
+| v2      | launchplan1 |      |       |          | numbers: short desc       |         |
+|         |             |      |       |          | numbers_count: long de... |         |
+|         |             |      |       |          | run_local_at_count        |         | 
+--------- ------------- ------ ------- ---------- --------------------------- --------- 
+| v1      | launchplan1 |      |       |          | numbers: short desc       |         |
+|         |             |      |       |          | numbers_count: long de... |         |
+|         |             |      |       |          | run_local_at_count        |         | 
+--------- ------------- ------ ------- ---------- --------------------------- --------- 
+2 rows`)
 }

--- a/cmd/get/task.go
+++ b/cmd/get/task.go
@@ -94,15 +94,15 @@ Check the create execution section on how to launch one using the generated file
 Usage
 `
 )
-const FormattedDescriptionsFieldKey = "_formatted_descriptions"
+const FormattedDescriptionsKey = "_formatted_descriptions"
 const DescriptionLineWidth = 25
 
 var taskColumns = []printer.Column{
 	{Header: "Version", JSONPath: "$.id.version"},
 	{Header: "Name", JSONPath: "$.id.name"},
 	{Header: "Type", JSONPath: "$.closure.compiledTask.template.type"},
-	{Header: "Inputs", JSONPath: "$.closure.compiledTask.template.interface.inputs.variables." + FormattedDescriptionsFieldKey + ".description"},
-	{Header: "Outputs", JSONPath: "$.closure.compiledTask.template.interface.outputs.variables." + FormattedDescriptionsFieldKey + ".description"},
+	{Header: "Inputs", JSONPath: "$.closure.compiledTask.template.interface.inputs.variables." + FormattedDescriptionsKey + ".description"},
+	{Header: "Outputs", JSONPath: "$.closure.compiledTask.template.interface.outputs.variables." + FormattedDescriptionsKey + ".description"},
 	{Header: "Discoverable", JSONPath: "$.closure.compiledTask.template.metadata.discoverable"},
 	{Header: "Discovery Version", JSONPath: "$.closure.compiledTask.template.metadata.discoveryVersion"},
 	{Header: "Created At", JSONPath: "$.closure.createdAt"},
@@ -128,7 +128,7 @@ func formatVariableDescriptions(variableMap map[string]*core.Variable) {
 			descriptions = append(descriptions, getTruncatedLine(k, DescriptionLineWidth))
 		}
 	}
-	variableMap[FormattedDescriptionsFieldKey] = &core.Variable{Description: strings.Join(descriptions, "\n")}
+	variableMap[FormattedDescriptionsKey] = &core.Variable{Description: strings.Join(descriptions, "\n")}
 }
 
 func getTruncatedLine(line string, width int) string {

--- a/cmd/get/task.go
+++ b/cmd/get/task.go
@@ -115,6 +115,7 @@ func TaskToProtoMessages(l []*admin.Task) []proto.Message {
 func TaskToTableProtoMessages(l []*admin.Task) []proto.Message {
 	messages := make([]proto.Message, 0, len(l))
 	for _, m := range l {
+		m := proto.Clone(m).(*admin.Task)
 		if m.Closure.CompiledTask.Template.Interface.Inputs != nil {
 			printer.FormatVariableDescriptions(m.Closure.CompiledTask.Template.Interface.Inputs.Variables)
 		}

--- a/cmd/get/workflow.go
+++ b/cmd/get/workflow.go
@@ -103,8 +103,13 @@ func WorkflowToProtoMessages(l []*admin.Workflow) []proto.Message {
 func WorkflowToTableProtoMessages(l []*admin.Workflow) []proto.Message {
 	messages := make([]proto.Message, 0, len(l))
 	for _, m := range l {
-		printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs.Variables)
-		printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs.Variables)
+		m := proto.Clone(m).(*admin.Workflow)
+		if m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs != nil {
+			printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs.Variables)
+		}
+		if m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs != nil {
+			printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs.Variables)
+		}
 		messages = append(messages, m)
 	}
 	return messages

--- a/cmd/testutils/test_utils.go
+++ b/cmd/testutils/test_utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -68,10 +69,12 @@ func TearDownAndVerify(t *testing.T, expectedLog string) {
 	os.Stderr = stderr
 	var buf bytes.Buffer
 	if _, err := io.Copy(&buf, reader); err == nil {
-		assert.Equal(t, santizeString(expectedLog), santizeString(buf.String()))
+		assert.Equal(t, sanitizeString(expectedLog), sanitizeString(buf.String()))
 	}
 }
 
-func santizeString(str string) string {
-	return strings.Trim(strings.ReplaceAll(strings.ReplaceAll(str, "\n", ""), "\t", ""), " \t")
+func sanitizeString(str string) string {
+	// Not the most comprehensive ANSI pattern, but this should capture common color operations such as \x1b[107;0m and \x1b[0m. Expand if needed (insert regex 2 problems joke here).
+	ansiRegex := regexp.MustCompile("\u001B\\[[\\d+\\;]*\\d+m")
+	return ansiRegex.ReplaceAllString(strings.Trim(strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(str, "\n", ""), "\t", ""), "", ""), " \t"), "")
 }

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	gotest.tools v2.2.0+incompatible
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -225,7 +225,7 @@ func FormatParameterDescriptions(variableMap map[string]*core.Parameter) {
 }
 
 func getTruncatedLine(line string) string {
-	// maybe add width to function signature later
+	// TODO: maybe add width to function signature later
 	width := defaultLineWidth
 	if len(line) > width {
 		return line[:width-3] + "..."

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -180,9 +180,6 @@ func FormatVariableDescriptions(variableMap map[string]*core.Variable) {
 
 	var descriptions []string
 	for _, k := range keys {
-		if k == DefaultFormattedDescriptionsKey {
-			continue
-		}
 		v := variableMap[k]
 		// a: a isn't very helpful
 		if k != v.Description {
@@ -204,11 +201,7 @@ func FormatParameterDescriptions(parameterMap map[string]*core.Parameter) {
 	sort.Strings(keys)
 
 	var descriptions []string
-	//for k, v := range variableMap {
 	for _, k := range keys {
-		if k == DefaultFormattedDescriptionsKey {
-			continue
-		}
 		v := parameterMap[k]
 		if v.Var == nil {
 			continue

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -179,7 +179,6 @@ func FormatVariableDescriptions(variableMap map[string]*core.Variable) {
 	sort.Strings(keys)
 
 	var descriptions []string
-	//for k, v := range variableMap {
 	for _, k := range keys {
 		if k == DefaultFormattedDescriptionsKey {
 			continue
@@ -197,9 +196,9 @@ func FormatVariableDescriptions(variableMap map[string]*core.Variable) {
 }
 
 func FormatParameterDescriptions(parameterMap map[string]*core.Parameter) {
-	keys := make([]string, 0, len(variableMap))
+	keys := make([]string, 0, len(parameterMap))
 	// sort the keys for testing and consistency with other output formats
-	for k := range variableMap {
+	for k := range parameterMap {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
@@ -210,7 +209,7 @@ func FormatParameterDescriptions(parameterMap map[string]*core.Parameter) {
 		if k == DefaultFormattedDescriptionsKey {
 			continue
 		}
-		v := variableMap[k]
+		v := parameterMap[k]
 		if v.Var == nil {
 			continue
 		}
@@ -221,7 +220,7 @@ func FormatParameterDescriptions(parameterMap map[string]*core.Parameter) {
 			descriptions = append(descriptions, getTruncatedLine(k))
 		}
 	}
-	variableMap[DefaultFormattedDescriptionsKey] = &core.Parameter{Var: &core.Variable{Description: strings.Join(descriptions, "\n")}}
+	parameterMap[DefaultFormattedDescriptionsKey] = &core.Parameter{Var: &core.Variable{Description: strings.Join(descriptions, "\n")}}
 }
 
 func getTruncatedLine(line string) string {

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -6,6 +6,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
+	"strings"
+
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
 	"github.com/flyteorg/flytectl/pkg/visualize"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -51,8 +55,10 @@ type Column struct {
 type Printer struct{}
 
 const (
-	empty = ""
-	tab   = "\t"
+	empty                           = ""
+	tab                             = "\t"
+	DefaultFormattedDescriptionsKey = "_formatted_descriptions"
+	defaultLineWidth                = 25
 )
 
 // Projects the columns in one row of data from the given JSON using the []Column map
@@ -162,6 +168,69 @@ func printJSONYaml(format OutputFormat, v interface{}) error {
 		fmt.Println(string(v))
 	}
 	return nil
+}
+
+func FormatVariableDescriptions(variableMap map[string]*core.Variable) {
+	keys := make([]string, 0, len(variableMap))
+	// sort the keys for testing and consistency with other output formats
+	for k := range variableMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var descriptions []string
+	//for k, v := range variableMap {
+	for _, k := range keys {
+		if k == DefaultFormattedDescriptionsKey {
+			continue
+		}
+		v := variableMap[k]
+		// a: a isn't very helpful
+		if k != v.Description {
+			descriptions = append(descriptions, getTruncatedLine(fmt.Sprintf("%s: %s", k, v.Description)))
+		} else {
+			descriptions = append(descriptions, getTruncatedLine(k))
+		}
+
+	}
+	variableMap[DefaultFormattedDescriptionsKey] = &core.Variable{Description: strings.Join(descriptions, "\n")}
+}
+
+func FormatParameterDescriptions(variableMap map[string]*core.Parameter) {
+	keys := make([]string, 0, len(variableMap))
+	// sort the keys for testing and consistency with other output formats
+	for k := range variableMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var descriptions []string
+	//for k, v := range variableMap {
+	for _, k := range keys {
+		if k == DefaultFormattedDescriptionsKey {
+			continue
+		}
+		v := variableMap[k]
+		if v.Var == nil {
+			continue
+		}
+		// a: a isn't very helpful
+		if k != v.Var.Description {
+			descriptions = append(descriptions, getTruncatedLine(fmt.Sprintf("%s: %s", k, v.Var.Description)))
+		} else {
+			descriptions = append(descriptions, getTruncatedLine(k))
+		}
+	}
+	variableMap[DefaultFormattedDescriptionsKey] = &core.Parameter{Var: &core.Variable{Description: strings.Join(descriptions, "\n")}}
+}
+
+func getTruncatedLine(line string) string {
+	// maybe add width to function signature later
+	width := defaultLineWidth
+	if len(line) > width {
+		return line[:width-3] + "..."
+	}
+	return line
 }
 
 func (p Printer) Print(format OutputFormat, columns []Column, messages ...proto.Message) error {

--- a/pkg/printer/printer.go
+++ b/pkg/printer/printer.go
@@ -196,7 +196,7 @@ func FormatVariableDescriptions(variableMap map[string]*core.Variable) {
 	variableMap[DefaultFormattedDescriptionsKey] = &core.Variable{Description: strings.Join(descriptions, "\n")}
 }
 
-func FormatParameterDescriptions(variableMap map[string]*core.Parameter) {
+func FormatParameterDescriptions(parameterMap map[string]*core.Parameter) {
 	keys := make([]string, 0, len(variableMap))
 	// sort the keys for testing and consistency with other output formats
 	for k := range variableMap {

--- a/pkg/printer/printer_test.go
+++ b/pkg/printer/printer_test.go
@@ -253,3 +253,57 @@ func TestPrint(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, fmt.Errorf("no template found in the sub workflow template:<> "), errors.Unwrap(err))
 }
+
+func TestGetTruncatedLine(t *testing.T) {
+	testStrings := map[string]string{
+		"foo":                        "foo",
+		"":                           "",
+		"short description":          "short description",
+		"1234567890123456789012345":  "1234567890123456789012345",
+		"12345678901234567890123456": "1234567890123456789012...",
+		"long description probably needs truncate": "long description proba...",
+	}
+	for k, v := range testStrings {
+		assert.Equal(t, v, getTruncatedLine(k))
+	}
+}
+
+func TestFormatVariableDescriptions(t *testing.T) {
+	fooVar := &core.Variable{
+		Description: "foo",
+	}
+	barVar := &core.Variable{
+		Description: "bar",
+	}
+	variableMap := map[string]*core.Variable{
+		"var1": fooVar,
+		"var2": barVar,
+		"foo":  fooVar,
+		"bar":  barVar,
+	}
+	FormatVariableDescriptions(variableMap)
+	assert.Equal(t, "bar\nfoo\nvar1: foo\nvar2: bar", variableMap[DefaultFormattedDescriptionsKey].Description)
+}
+
+func TestFormatParameterDescriptions(t *testing.T) {
+	fooParam := &core.Parameter{
+		Var: &core.Variable{
+			Description: "foo",
+		},
+	}
+	barParam := &core.Parameter{
+		Var: &core.Variable{
+			Description: "bar",
+		},
+	}
+	emptyParam := &core.Parameter{}
+	paramMap := map[string]*core.Parameter{
+		"var1":  fooParam,
+		"var2":  barParam,
+		"foo":   fooParam,
+		"bar":   barParam,
+		"empty": emptyParam,
+	}
+	FormatParameterDescriptions(paramMap)
+	assert.Equal(t, "bar\nfoo\nvar1: foo\nvar2: bar", paramMap[DefaultFormattedDescriptionsKey].Var.Description)
+}


### PR DESCRIPTION
# TL;DR
- Display input output variable description in the table view of `get task` `get workflow` `get launchplan`.
- Display input output variable description as comment when generating an execution spec template.

`get launchplan`
![Screen Shot 2021-08-02 at 11 17 58](https://user-images.githubusercontent.com/6239450/127906119-e7da94d2-5d11-41b8-9fe7-95b8e151d176.png)

`get workflow`
![Screen Shot 2021-08-02 at 11 18 18](https://user-images.githubusercontent.com/6239450/127906127-e054557b-df0a-47a5-8ae7-87e68446d41c.png)

`get task`
![Screen Shot 2021-08-02 at 11 21 13](https://user-images.githubusercontent.com/6239450/127906561-83aad298-5763-4129-9835-2841a0076f66.png)

`get task --exexFile exec.yaml` before vs after
![Screen Shot 2021-07-29 at 16 44 15](https://user-images.githubusercontent.com/6239450/127906282-5a40252d-bbf2-435a-bb3d-a4c2884515a0.png)



## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1281

## Follow-up issue
_NA_
