### PR TITLE
Remove input output columns for list workflows

### DIFF
--- a/cmd/get/launch_plan_test.go
+++ b/cmd/get/launch_plan_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/flyteorg/flytectl/pkg/printer"
+
 	"github.com/flyteorg/flytectl/pkg/filters"
 
 	"github.com/flyteorg/flytectl/cmd/config"
@@ -731,7 +733,7 @@ func TestGetLaunchPlanTableFunc(t *testing.T) {
 	mockClient.OnListLaunchPlansMatch(ctx, resourceGetRequest).Return(launchPlanListResponse, nil)
 	mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
 	mockClient.OnListLaunchPlanIdsMatch(ctx, namedIDRequest).Return(namedIdentifierList, nil)
-	config.GetConfig().Output = "table"
+	config.GetConfig().Output = printer.OutputFormatTABLE.String()
 	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 	assert.Nil(t, err)
 	mockClient.AssertCalled(t, "ListLaunchPlans", ctx, resourceGetRequest)

--- a/cmd/get/task_test.go
+++ b/cmd/get/task_test.go
@@ -319,7 +319,7 @@ func TestGetTaskFunc(t *testing.T) {
 ]`)
 }
 
-func TestGetTaskTableFunc(t *testing.T) {
+func TestGetTaskFuncWithTable(t *testing.T) {
 	setup()
 	getTaskSetup()
 	taskConfig.DefaultConfig.Filter = filters.Filters{}

--- a/cmd/get/workflow.go
+++ b/cmd/get/workflow.go
@@ -92,6 +92,12 @@ var workflowColumns = []printer.Column{
 	{Header: "Created At", JSONPath: "$.closure.createdAt"},
 }
 
+var listWorkflowColumns = []printer.Column{
+	{Header: "Version", JSONPath: "$.id.version"},
+	{Header: "Name", JSONPath: "$.id.name"},
+	{Header: "Created At", JSONPath: "$.closure.createdAt"},
+}
+
 func WorkflowToProtoMessages(l []*admin.Workflow) []proto.Message {
 	messages := make([]proto.Message, 0, len(l))
 	for _, m := range l {
@@ -129,14 +135,19 @@ func getWorkflowFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandC
 	var err error
 	if len(args) > 0 {
 		name := args[0]
-		if workflows, err = FetchWorkflowForName(ctx, cmdCtx.AdminFetcherExt(), name, config.GetConfig().Project, config.GetConfig().Domain); err != nil {
+		var isList bool
+		if workflows, isList, err = FetchWorkflowForName(ctx, cmdCtx.AdminFetcherExt(), name, config.GetConfig().Project, config.GetConfig().Domain); err != nil {
 			return err
+		}
+		columns := workflowColumns
+		if isList {
+			columns = listWorkflowColumns
 		}
 		logger.Debugf(ctx, "Retrieved %v workflow", len(workflows))
 		if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
-			return adminPrinter.Print(config.GetConfig().MustOutputFormat(), workflowColumns, WorkflowToTableProtoMessages(workflows)...)
+			return adminPrinter.Print(config.GetConfig().MustOutputFormat(), columns, WorkflowToTableProtoMessages(workflows)...)
 		}
-		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), workflowColumns, WorkflowToProtoMessages(workflows)...)
+		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), columns, WorkflowToProtoMessages(workflows)...)
 	}
 
 	workflows, err = cmdCtx.AdminFetcherExt().FetchAllVerOfWorkflow(ctx, "", config.GetConfig().Project, config.GetConfig().Domain, workflowconfig.DefaultConfig.Filter)
@@ -146,32 +157,34 @@ func getWorkflowFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandC
 
 	logger.Debugf(ctx, "Retrieved %v workflows", len(workflows))
 	if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
-		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), workflowColumns, WorkflowToTableProtoMessages(workflows)...)
+		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), listWorkflowColumns, WorkflowToTableProtoMessages(workflows)...)
 	}
-	return adminPrinter.Print(config.GetConfig().MustOutputFormat(), workflowColumns, WorkflowToProtoMessages(workflows)...)
+	return adminPrinter.Print(config.GetConfig().MustOutputFormat(), listWorkflowColumns, WorkflowToProtoMessages(workflows)...)
 }
 
 // FetchWorkflowForName fetches the workflow give it name.
 func FetchWorkflowForName(ctx context.Context, fetcher ext.AdminFetcherExtInterface, name, project,
-	domain string) ([]*admin.Workflow, error) {
+	domain string) ([]*admin.Workflow, bool, error) {
 	var workflows []*admin.Workflow
 	var workflow *admin.Workflow
+	var isList bool
 	var err error
 	if workflowconfig.DefaultConfig.Latest {
 		if workflow, err = fetcher.FetchWorkflowLatestVersion(ctx, name, project, domain, workflowconfig.DefaultConfig.Filter); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		workflows = append(workflows, workflow)
 	} else if workflowconfig.DefaultConfig.Version != "" {
 		if workflow, err = fetcher.FetchWorkflowVersion(ctx, name, workflowconfig.DefaultConfig.Version, project, domain); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		workflows = append(workflows, workflow)
 	} else {
 		workflows, err = fetcher.FetchAllVerOfWorkflow(ctx, name, project, domain, workflowconfig.DefaultConfig.Filter)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		isList = true
 	}
-	return workflows, nil
+	return workflows, isList, nil
 }

--- a/cmd/get/workflow.go
+++ b/cmd/get/workflow.go
@@ -164,11 +164,8 @@ func getWorkflowFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandC
 
 // FetchWorkflowForName fetches the workflow give it name.
 func FetchWorkflowForName(ctx context.Context, fetcher ext.AdminFetcherExtInterface, name, project,
-	domain string) ([]*admin.Workflow, bool, error) {
-	var workflows []*admin.Workflow
+	domain string) (workflows []*admin.Workflow, isList bool, err error) {
 	var workflow *admin.Workflow
-	var isList bool
-	var err error
 	if workflowconfig.DefaultConfig.Latest {
 		if workflow, err = fetcher.FetchWorkflowLatestVersion(ctx, name, project, domain, workflowconfig.DefaultConfig.Filter); err != nil {
 			return nil, false, err

--- a/cmd/get/workflow_test.go
+++ b/cmd/get/workflow_test.go
@@ -59,7 +59,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		workflow.DefaultConfig.Latest = true
 		mockFetcher.OnFetchWorkflowLatestVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("error fetching latest version"))
-		_, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
+		_, _, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
 		assert.NotNil(t, err)
 	})
 
@@ -70,7 +70,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 		workflow.DefaultConfig.Version = "v1"
 		mockFetcher.OnFetchWorkflowVersionMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything).Return(nil, fmt.Errorf("error fetching version"))
-		_, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
+		_, _, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
 		assert.NotNil(t, err)
 	})
 
@@ -80,7 +80,7 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 		mockFetcher := new(mocks.AdminFetcherExtInterface)
 		mockFetcher.OnFetchAllVerOfWorkflowMatch(mock.Anything, mock.Anything, mock.Anything,
 			mock.Anything, mock.Anything).Return(nil, fmt.Errorf("error fetching all version"))
-		_, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
+		_, _, err = FetchWorkflowForName(ctx, mockFetcher, "workflowName", projectValue, domainValue)
 		assert.NotNil(t, err)
 	})
 

--- a/cmd/get/workflow_test.go
+++ b/cmd/get/workflow_test.go
@@ -4,6 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/flyteorg/flytectl/cmd/config"
+	"github.com/flyteorg/flytectl/pkg/filters"
+	"github.com/flyteorg/flytectl/pkg/printer"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/flyteorg/flytectl/pkg/ext/mocks"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
@@ -17,6 +23,9 @@ import (
 var (
 	resourceListRequestWorkflow *admin.ResourceListRequest
 	workflowListResponse        *admin.WorkflowList
+	argsWf                      []string
+	workflow1                   *admin.Workflow
+	workflows                   []*admin.Workflow
 )
 
 func getWorkflowSetup() {
@@ -30,11 +39,52 @@ func getWorkflowSetup() {
 		},
 	}
 
-	workflow1 := &admin.Workflow{
+	variableMap := map[string]*core.Variable{
+		"var1": {
+			Type: &core.LiteralType{
+				Type: &core.LiteralType_CollectionType{
+					CollectionType: &core.LiteralType{
+						Type: &core.LiteralType_Simple{
+							Simple: core.SimpleType_INTEGER,
+						},
+					},
+				},
+			},
+			Description: "var1",
+		},
+		"var2": {
+			Type: &core.LiteralType{
+				Type: &core.LiteralType_CollectionType{
+					CollectionType: &core.LiteralType{
+						Type: &core.LiteralType_Simple{
+							Simple: core.SimpleType_INTEGER,
+						},
+					},
+				},
+			},
+			Description: "var2 long descriptions probably needs truncate",
+		},
+	}
+	workflow1 = &admin.Workflow{
 		Id: &core.Identifier{
 			Project: projectValue,
 			Domain:  domainValue,
 			Name:    "workflow1",
+			Version: "v1",
+		},
+		Closure: &admin.WorkflowClosure{
+			CreatedAt: &timestamppb.Timestamp{Seconds: 0, Nanos: 0},
+			CompiledWorkflow: &core.CompiledWorkflowClosure{
+				Primary: &core.CompiledWorkflow{
+					Template: &core.WorkflowTemplate{
+						Interface: &core.TypedInterface{
+							Inputs: &core.VariableMap{
+								Variables: variableMap,
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	workflow2 := &admin.Workflow{
@@ -42,14 +92,20 @@ func getWorkflowSetup() {
 			Project: projectValue,
 			Domain:  domainValue,
 			Name:    "workflow2",
+			Version: "v2",
+		},
+		Closure: &admin.WorkflowClosure{
+			CreatedAt: &timestamppb.Timestamp{Seconds: 0, Nanos: 0},
 		},
 	}
-	workflows := []*admin.Workflow{workflow1, workflow2}
+	workflows = []*admin.Workflow{workflow1, workflow2}
 	workflowListResponse = &admin.WorkflowList{
 		Workflows: workflows,
 	}
+	argsWf = []string{"workflow1"}
 	workflow.DefaultConfig.Latest = false
 	workflow.DefaultConfig.Version = ""
+	workflow.DefaultConfig.Filter = filters.DefaultFilter
 }
 
 func TestGetWorkflowFuncWithError(t *testing.T) {
@@ -95,4 +151,42 @@ func TestGetWorkflowFuncWithError(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 
+}
+
+func TestGetWorkflowFuncLatestWithTable(t *testing.T) {
+	setup()
+	getWorkflowSetup()
+	workflow.DefaultConfig.Latest = true
+	workflow.DefaultConfig.Filter = filters.Filters{}
+	config.GetConfig().Output = printer.OutputFormatTABLE.String()
+	u.FetcherExt.OnFetchWorkflowLatestVersionMatch(ctx, "workflow1", projectValue, domainValue, filters.Filters{}).Return(workflow1, nil)
+	err = getWorkflowFunc(ctx, argsWf, cmdCtx)
+	assert.Nil(t, err)
+	tearDownAndVerify(t, `
+ --------- ----------- --------------------------- --------- ---------------------- 
+| VERSION | NAME      | INPUTS                    | OUTPUTS | CREATED AT           |
+ --------- ----------- --------------------------- --------- ---------------------- 
+| v1      | workflow1 | var1                      |         | 1970-01-01T00:00:00Z |
+|         |           | var2: var2 long descri... |         |                      |
+ --------- ----------- --------------------------- --------- ---------------------- 
+1 rows`)
+}
+
+func TestListWorkflowFuncWithTable(t *testing.T) {
+	setup()
+	getWorkflowSetup()
+	workflow.DefaultConfig.Filter = filters.Filters{}
+	config.GetConfig().Output = printer.OutputFormatTABLE.String()
+	u.FetcherExt.OnFetchAllVerOfWorkflowMatch(ctx, "workflow1", projectValue, domainValue, filters.Filters{}).Return(workflows, nil)
+	err = getWorkflowFunc(ctx, argsWf, cmdCtx)
+	assert.Nil(t, err)
+	tearDownAndVerify(t, `
+ --------- ----------- ---------------------- 
+| VERSION | NAME      | CREATED AT           |
+ --------- ----------- ---------------------- 
+| v1      | workflow1 | 1970-01-01T00:00:00Z |
+ --------- ----------- ---------------------- 
+| v2      | workflow2 | 1970-01-01T00:00:00Z |
+ --------- ----------- ---------------------- 
+2 rows`)
 }


### PR DESCRIPTION
# TL;DR
The workflow interface is not returned for listing requests, which makes the get workflow table look rather empty sometimes:
![Screen Shot 2021-08-05 at 19 25 42](https://user-images.githubusercontent.com/6239450/128574964-b7f056f7-7310-4a1b-b1cc-d79b094d4a1f.png)

This PR removes the input output columns from the table if list workflow is called while keeping the table intact for when fetching a single workflow.
![Screen Shot 2021-08-06 at 14 30 35](https://user-images.githubusercontent.com/6239450/128575192-0b526ad8-aa1e-4ca6-9987-44c39abedc6e.png)


## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
_NA_

## Follow-up issue
_NA_
