### PR TITLE
#patch fix panic for GET cmd w table output

### DIFF
--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -132,7 +132,7 @@ func LaunchplanToTableProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 			if m.Closure.ExpectedInputs != nil {
 				printer.FormatParameterDescriptions(m.Closure.ExpectedInputs.Parameters)
 			}
-			if m.Closure.ExpectedOutputs != nil {
+			if m.Closure.ExpectedOutputs != nil && m.Closure.ExpectedOutputs.Variables != nil {
 				printer.FormatVariableDescriptions(m.Closure.ExpectedOutputs.Variables)
 			}
 		}

--- a/cmd/get/task.go
+++ b/cmd/get/task.go
@@ -119,10 +119,10 @@ func TaskToTableProtoMessages(l []*admin.Task) []proto.Message {
 		if m.Closure != nil && m.Closure.CompiledTask != nil {
 			if m.Closure.CompiledTask.Template != nil {
 				if m.Closure.CompiledTask.Template.Interface != nil {
-					if m.Closure.CompiledTask.Template.Interface.Inputs != nil {
+					if m.Closure.CompiledTask.Template.Interface.Inputs != nil && m.Closure.CompiledTask.Template.Interface.Inputs.Variables != nil {
 						printer.FormatVariableDescriptions(m.Closure.CompiledTask.Template.Interface.Inputs.Variables)
 					}
-					if m.Closure.CompiledTask.Template.Interface.Outputs != nil {
+					if m.Closure.CompiledTask.Template.Interface.Outputs != nil && m.Closure.CompiledTask.Template.Interface.Outputs.Variables != nil {
 						printer.FormatVariableDescriptions(m.Closure.CompiledTask.Template.Interface.Outputs.Variables)
 					}
 				}

--- a/cmd/get/workflow.go
+++ b/cmd/get/workflow.go
@@ -114,10 +114,10 @@ func WorkflowToTableProtoMessages(l []*admin.Workflow) []proto.Message {
 			if m.Closure.CompiledWorkflow.Primary != nil {
 				if m.Closure.CompiledWorkflow.Primary.Template != nil {
 					if m.Closure.CompiledWorkflow.Primary.Template.Interface != nil {
-						if m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs != nil {
+						if m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs != nil && m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs.Variables != nil {
 							printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Inputs.Variables)
 						}
-						if m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs != nil {
+						if m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs != nil && m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs.Variables != nil {
 							printer.FormatVariableDescriptions(m.Closure.CompiledWorkflow.Primary.Template.Interface.Outputs.Variables)
 						}
 					}


### PR DESCRIPTION





# TL;DR
Suggested fix for https://github.com/flyteorg/flyte/issues/1396. 

nil checks exists for ExpectedOutput container but not on the Variables map pointer itself prior to calling, and nil argument causes a panic.
Added nil check on map argument to `FormatVariableDescriptions at pkg/printer/printer.go:173` prior to calling in all places found.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
As described in https://github.com/flyteorg/flyte/issues/1396 flytectl panics for get resource command if resource is missing `ExpectedOutput.Variables` 

Prior to fix
```
$ go run ./main.go get launchplans -p demo-1 -d production --latest demo-1.no-output

panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/flyteorg/flytectl/pkg/printer.FormatVariableDescriptions(0x0)
	/workspace/flyteorg/flytectl/pkg/printer/printer.go:202 +0x307
github.com/flyteorg/flytectl/cmd/get.LaunchplanToTableProtoMessages({0xc000a30938, 0x1, 0x7ffeefbff977})
	/workspace/flyteorg/flytectl/cmd/get/launch_plan.go:136 +0xee
github.com/flyteorg/flytectl/cmd/get.getLaunchPlanFunc({0x2dfbf98, 0xc0000580b8}, {0xc0002fb8c0, 0x1, 0x11519b4}, {{0x2e55850, 0xc000a30120}, {0x2e472c0, 0xc0009a3110}, {0x2ddff60, ...}, ...})
	/workspace/flyteorg/flytectl/cmd/get/launch_plan.go:158 +0x307
github.com/flyteorg/flytectl/cmd/core.generateCommandFunc.func1(0xc000481680, {0xc0002fb8c0, 0x1, 0x6})
	/workspace/flyteorg/flytectl/cmd/core/cmd.go:69 +0x47d
github.com/spf13/cobra.(*Command).execute(0xc000481680, {0xc0002fb860, 0x6, 0x6})
	/workspace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:852 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc000480000)
	/workspace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:960 +0x3ad
github.com/spf13/cobra.(*Command).Execute(...)
	/workspace/go/pkg/mod/github.com/spf13/cobra@v1.1.3/command.go:897
github.com/flyteorg/flytectl/cmd.ExecuteCmd()
	/workspace/flyteorg/flytectl/cmd/root.go:135 +0x1e
main.main()
	/workspace/flyteorg/flytectl/main.go:12 +0x1d
exit status 2
```

With this fix I get expected output, a table style output with empty value for output.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1396

Signed-off-by: Viktor Gerdin <viktorg@spotify.com>
