### PR TITLE
Hotfix register example

### DIFF
--- a/cmd/config/subcommand/register/files_config.go
+++ b/cmd/config/subcommand/register/files_config.go
@@ -16,7 +16,7 @@ type FilesConfig struct {
 	Archive              bool   `json:"archive" pflag:",pass in archive file either an http link or local path."`
 	AssumableIamRole     string `json:"assumableIamRole" pflag:", custom assumable iam auth role to register launch plans with."`
 	K8sServiceAccount    string `json:"k8sServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
-	K8ServiceAccount     string `json:"k8sServiceAccount" pflag:", deprecated. Please use --K8sServiceAccount"`
+	K8ServiceAccount     string `json:"k8ServiceAccount" pflag:", deprecated. Please use --K8sServiceAccount"`
 	OutputLocationPrefix string `json:"outputLocationPrefix" pflag:", custom output location prefix for offloaded types (files/schemas)."`
 	SourceUploadPath     string `json:"sourceUploadPath" pflag:", Location for source code in storage."`
 	DryRun               bool   `json:"dryRun" pflag:",execute command without making any modifications."`

--- a/cmd/config/subcommand/register/files_config.go
+++ b/cmd/config/subcommand/register/files_config.go
@@ -15,7 +15,7 @@ type FilesConfig struct {
 	ContinueOnError      bool   `json:"continueOnError" pflag:",continue on error when registering files."`
 	Archive              bool   `json:"archive" pflag:",pass in archive file either an http link or local path."`
 	AssumableIamRole     string `json:"assumableIamRole" pflag:", custom assumable iam auth role to register launch plans with."`
-	K8sServiceAccount     string `json:"k8sServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
+	K8sServiceAccount    string `json:"k8sServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
 	OutputLocationPrefix string `json:"outputLocationPrefix" pflag:", custom output location prefix for offloaded types (files/schemas)."`
 	SourceUploadPath     string `json:"sourceUploadPath" pflag:", Location for source code in storage."`
 	DryRun               bool   `json:"dryRun" pflag:",execute command without making any modifications."`

--- a/cmd/config/subcommand/register/files_config.go
+++ b/cmd/config/subcommand/register/files_config.go
@@ -15,7 +15,7 @@ type FilesConfig struct {
 	ContinueOnError      bool   `json:"continueOnError" pflag:",continue on error when registering files."`
 	Archive              bool   `json:"archive" pflag:",pass in archive file either an http link or local path."`
 	AssumableIamRole     string `json:"assumableIamRole" pflag:", custom assumable iam auth role to register launch plans with."`
-	K8ServiceAccount     string `json:"k8ServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
+	K8sServiceAccount     string `json:"k8sServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
 	OutputLocationPrefix string `json:"outputLocationPrefix" pflag:", custom output location prefix for offloaded types (files/schemas)."`
 	SourceUploadPath     string `json:"sourceUploadPath" pflag:", Location for source code in storage."`
 	DryRun               bool   `json:"dryRun" pflag:",execute command without making any modifications."`

--- a/cmd/config/subcommand/register/files_config.go
+++ b/cmd/config/subcommand/register/files_config.go
@@ -16,6 +16,7 @@ type FilesConfig struct {
 	Archive              bool   `json:"archive" pflag:",pass in archive file either an http link or local path."`
 	AssumableIamRole     string `json:"assumableIamRole" pflag:", custom assumable iam auth role to register launch plans with."`
 	K8sServiceAccount    string `json:"k8sServiceAccount" pflag:", custom kubernetes service account auth role to register launch plans with."`
+	K8ServiceAccount     string `json:"k8sServiceAccount" pflag:", deprecated. Please use --K8sServiceAccount"`
 	OutputLocationPrefix string `json:"outputLocationPrefix" pflag:", custom output location prefix for offloaded types (files/schemas)."`
 	SourceUploadPath     string `json:"sourceUploadPath" pflag:", Location for source code in storage."`
 	DryRun               bool   `json:"dryRun" pflag:",execute command without making any modifications."`

--- a/cmd/config/subcommand/register/filesconfig_flags.go
+++ b/cmd/config/subcommand/register/filesconfig_flags.go
@@ -55,7 +55,7 @@ func (cfg FilesConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.BoolVar(&DefaultFilesConfig.Archive, fmt.Sprintf("%v%v", prefix, "archive"), DefaultFilesConfig.Archive, "pass in archive file either an http link or local path.")
 	cmdFlags.StringVar(&DefaultFilesConfig.AssumableIamRole, fmt.Sprintf("%v%v", prefix, "assumableIamRole"), DefaultFilesConfig.AssumableIamRole, " custom assumable iam auth role to register launch plans with.")
 	cmdFlags.StringVar(&DefaultFilesConfig.K8sServiceAccount, fmt.Sprintf("%v%v", prefix, "k8sServiceAccount"), DefaultFilesConfig.K8sServiceAccount, " custom kubernetes service account auth role to register launch plans with.")
-	cmdFlags.StringVar(&DefaultFilesConfig.K8ServiceAccount, fmt.Sprintf("%v%v", prefix, "k8sServiceAccount"), DefaultFilesConfig.K8ServiceAccount, " deprecated. Please use --K8sServiceAccount")
+	cmdFlags.StringVar(&DefaultFilesConfig.K8ServiceAccount, fmt.Sprintf("%v%v", prefix, "k8ServiceAccount"), DefaultFilesConfig.K8ServiceAccount, " deprecated. Please use --K8sServiceAccount")
 	cmdFlags.StringVar(&DefaultFilesConfig.OutputLocationPrefix, fmt.Sprintf("%v%v", prefix, "outputLocationPrefix"), DefaultFilesConfig.OutputLocationPrefix, " custom output location prefix for offloaded types (files/schemas).")
 	cmdFlags.StringVar(&DefaultFilesConfig.SourceUploadPath, fmt.Sprintf("%v%v", prefix, "sourceUploadPath"), DefaultFilesConfig.SourceUploadPath, " Location for source code in storage.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.DryRun, fmt.Sprintf("%v%v", prefix, "dryRun"), DefaultFilesConfig.DryRun, "execute command without making any modifications.")

--- a/cmd/config/subcommand/register/filesconfig_flags.go
+++ b/cmd/config/subcommand/register/filesconfig_flags.go
@@ -55,6 +55,7 @@ func (cfg FilesConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.BoolVar(&DefaultFilesConfig.Archive, fmt.Sprintf("%v%v", prefix, "archive"), DefaultFilesConfig.Archive, "pass in archive file either an http link or local path.")
 	cmdFlags.StringVar(&DefaultFilesConfig.AssumableIamRole, fmt.Sprintf("%v%v", prefix, "assumableIamRole"), DefaultFilesConfig.AssumableIamRole, " custom assumable iam auth role to register launch plans with.")
 	cmdFlags.StringVar(&DefaultFilesConfig.K8sServiceAccount, fmt.Sprintf("%v%v", prefix, "k8sServiceAccount"), DefaultFilesConfig.K8sServiceAccount, " custom kubernetes service account auth role to register launch plans with.")
+	cmdFlags.StringVar(&DefaultFilesConfig.K8ServiceAccount, fmt.Sprintf("%v%v", prefix, "k8sServiceAccount"), DefaultFilesConfig.K8ServiceAccount, " deprecated. Please use --K8sServiceAccount")
 	cmdFlags.StringVar(&DefaultFilesConfig.OutputLocationPrefix, fmt.Sprintf("%v%v", prefix, "outputLocationPrefix"), DefaultFilesConfig.OutputLocationPrefix, " custom output location prefix for offloaded types (files/schemas).")
 	cmdFlags.StringVar(&DefaultFilesConfig.SourceUploadPath, fmt.Sprintf("%v%v", prefix, "sourceUploadPath"), DefaultFilesConfig.SourceUploadPath, " Location for source code in storage.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.DryRun, fmt.Sprintf("%v%v", prefix, "dryRun"), DefaultFilesConfig.DryRun, "execute command without making any modifications.")

--- a/cmd/config/subcommand/register/filesconfig_flags.go
+++ b/cmd/config/subcommand/register/filesconfig_flags.go
@@ -54,7 +54,7 @@ func (cfg FilesConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.BoolVar(&DefaultFilesConfig.ContinueOnError, fmt.Sprintf("%v%v", prefix, "continueOnError"), DefaultFilesConfig.ContinueOnError, "continue on error when registering files.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.Archive, fmt.Sprintf("%v%v", prefix, "archive"), DefaultFilesConfig.Archive, "pass in archive file either an http link or local path.")
 	cmdFlags.StringVar(&DefaultFilesConfig.AssumableIamRole, fmt.Sprintf("%v%v", prefix, "assumableIamRole"), DefaultFilesConfig.AssumableIamRole, " custom assumable iam auth role to register launch plans with.")
-	cmdFlags.StringVar(&DefaultFilesConfig.K8ServiceAccount, fmt.Sprintf("%v%v", prefix, "k8ServiceAccount"), DefaultFilesConfig.K8ServiceAccount, " custom kubernetes service account auth role to register launch plans with.")
+	cmdFlags.StringVar(&DefaultFilesConfig.K8sServiceAccount, fmt.Sprintf("%v%v", prefix, "k8sServiceAccount"), DefaultFilesConfig.K8sServiceAccount, " custom kubernetes service account auth role to register launch plans with.")
 	cmdFlags.StringVar(&DefaultFilesConfig.OutputLocationPrefix, fmt.Sprintf("%v%v", prefix, "outputLocationPrefix"), DefaultFilesConfig.OutputLocationPrefix, " custom output location prefix for offloaded types (files/schemas).")
 	cmdFlags.StringVar(&DefaultFilesConfig.SourceUploadPath, fmt.Sprintf("%v%v", prefix, "sourceUploadPath"), DefaultFilesConfig.SourceUploadPath, " Location for source code in storage.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.DryRun, fmt.Sprintf("%v%v", prefix, "dryRun"), DefaultFilesConfig.DryRun, "execute command without making any modifications.")

--- a/cmd/config/subcommand/register/filesconfig_flags_test.go
+++ b/cmd/config/subcommand/register/filesconfig_flags_test.go
@@ -169,13 +169,13 @@ func TestFilesConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_k8sServiceAccount", func(t *testing.T) {
+	t.Run("Test_k8ServiceAccount", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("k8sServiceAccount", testValue)
-			if vString, err := cmdFlags.GetString("k8sServiceAccount"); err == nil {
+			cmdFlags.Set("k8ServiceAccount", testValue)
+			if vString, err := cmdFlags.GetString("k8ServiceAccount"); err == nil {
 				testDecodeJson_FilesConfig(t, fmt.Sprintf("%v", vString), &actual.K8ServiceAccount)
 
 			} else {

--- a/cmd/config/subcommand/register/filesconfig_flags_test.go
+++ b/cmd/config/subcommand/register/filesconfig_flags_test.go
@@ -155,14 +155,14 @@ func TestFilesConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_k8ServiceAccount", func(t *testing.T) {
+	t.Run("Test_k8sServiceAccount", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {
 			testValue := "1"
 
-			cmdFlags.Set("k8ServiceAccount", testValue)
-			if vString, err := cmdFlags.GetString("k8ServiceAccount"); err == nil {
-				testDecodeJson_FilesConfig(t, fmt.Sprintf("%v", vString), &actual.K8ServiceAccount)
+			cmdFlags.Set("k8sServiceAccount", testValue)
+			if vString, err := cmdFlags.GetString("k8sServiceAccount"); err == nil {
+				testDecodeJson_FilesConfig(t, fmt.Sprintf("%v", vString), &actual.K8sServiceAccount)
 
 			} else {
 				assert.FailNow(t, err.Error())

--- a/cmd/config/subcommand/register/filesconfig_flags_test.go
+++ b/cmd/config/subcommand/register/filesconfig_flags_test.go
@@ -169,6 +169,20 @@ func TestFilesConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_k8sServiceAccount", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("k8sServiceAccount", testValue)
+			if vString, err := cmdFlags.GetString("k8sServiceAccount"); err == nil {
+				testDecodeJson_FilesConfig(t, fmt.Sprintf("%v", vString), &actual.K8ServiceAccount)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_outputLocationPrefix", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/cmd/register/examples.go
+++ b/cmd/register/examples.go
@@ -36,6 +36,10 @@ var (
 func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
 	var examples []github.ReleaseAsset
 	var release string
+
+	// Deprecated checks for --k8Service
+	deprecatedCheck(ctx)
+
 	if len(args) == 1 {
 		release = args[0]
 	}

--- a/cmd/register/examples.go
+++ b/cmd/register/examples.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/flyteorg/flytestdlib/logger"
+
 	"github.com/google/go-github/github"
 
 	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
@@ -48,6 +50,7 @@ func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.Com
 		return err
 	}
 
+	logger.Infof(ctx, "Register started for %s %s release https://github.com/%s/%s/releases/tag/%s", flytesnacksRepository, tag, githubOrg, flytesnacksRepository, tag)
 	rconfig.DefaultFilesConfig.Archive = true
 	rconfig.DefaultFilesConfig.Version = tag
 	for _, v := range examples {

--- a/cmd/register/examples.go
+++ b/cmd/register/examples.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/go-github/github"
+
 	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 )
@@ -16,27 +18,37 @@ Registers all latest flytesnacks example
 
  bin/flytectl register examples  -d development  -p flytesnacks
 
+Registers specific release of flytesnacks example
+::
 
+ bin/flytectl register examples  -d development  -p flytesnacks v0.2.176
+	
+Note: register command automatically override the version with release version	
 Usage
 `
 )
 
 var (
-	githubOrg        = "flyteorg"
-	githubRepository = "flytesnacks"
-	snackReleaseURL  = "https://github.com/flyteorg/flytesnacks/releases/download/%s/flytesnacks-%s.tgz"
-	flyteManifest    = "https://github.com/flyteorg/flytesnacks/releases/download/%s/flyte_tests_manifest.json"
+	githubOrg             = "flyteorg"
+	flytesnacksRepository = "flytesnacks"
 )
 
 func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	flytesnacks, tag, err := getFlyteTestManifest(githubOrg, githubRepository)
+	var examples []github.ReleaseAsset
+	var release string
+	if len(args) == 1 {
+		release = args[0]
+	}
+	examples, tag, err := getAllFlytesnacksExample(githubOrg, flytesnacksRepository, release)
 	if err != nil {
 		return err
 	}
+
 	rconfig.DefaultFilesConfig.Archive = true
-	for _, v := range flytesnacks {
+	rconfig.DefaultFilesConfig.Version = tag
+	for _, v := range examples {
 		args := []string{
-			fmt.Sprintf(snackReleaseURL, tag, v.Name),
+			*v.BrowserDownloadURL,
 		}
 		if err := Register(ctx, args, cmdCtx); err != nil {
 			return fmt.Errorf("Example %v failed to register %v", v.Name, err)

--- a/cmd/register/examples_test.go
+++ b/cmd/register/examples_test.go
@@ -16,11 +16,11 @@ func TestRegisterExamplesFunc(t *testing.T) {
 func TestRegisterExamplesFuncErr(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	githubRepository = "testingsnacks"
+	flytesnacksRepository = "testingsnacks"
 	args = []string{""}
 
 	err := registerExamplesFunc(ctx, args, cmdCtx)
 	// TODO (Yuvraj) make test to success after fixing flytesnacks bug
 	assert.NotNil(t, err)
-	githubRepository = "flytesnacks"
+	flytesnacksRepository = "flytesnacks"
 }

--- a/cmd/register/files.go
+++ b/cmd/register/files.go
@@ -99,6 +99,9 @@ func Register(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext)
 	var _err error
 	var dataRefs []string
 
+	// Deprecated checks for --k8Service
+	deprecatedCheck(ctx)
+
 	// getSerializeOutputFiles will return you all proto and  source code compress file in sorted order
 	dataRefs, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	if err != nil {

--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -481,7 +481,7 @@ func getAllFlytesnacksExample(org, repository, release string) ([]github.Release
 	if len(releases) == 0 {
 		return nil, "", fmt.Errorf("repository doesn't have any release")
 	}
-	return filterExampleFromRelease(*releases[0]), release, nil
+	return filterExampleFromRelease(*releases[0]), *releases[0].TagName, nil
 
 }
 

--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -228,9 +228,9 @@ func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string) error {
 
 func hydrateLaunchPlanSpec(lpSpec *admin.LaunchPlanSpec) {
 	assumableIamRole := len(rconfig.DefaultFilesConfig.AssumableIamRole) > 0
-	k8ServiceAcct := len(rconfig.DefaultFilesConfig.K8sServiceAccount) > 0
+	k8sServiceAcct := len(rconfig.DefaultFilesConfig.K8sServiceAccount) > 0
 	outputLocationPrefix := len(rconfig.DefaultFilesConfig.OutputLocationPrefix) > 0
-	if assumableIamRole || k8ServiceAcct {
+	if assumableIamRole || k8sServiceAcct {
 		lpSpec.AuthRole = &admin.AuthRole{
 			AssumableIamRole:         rconfig.DefaultFilesConfig.AssumableIamRole,
 			KubernetesServiceAccount: rconfig.DefaultFilesConfig.K8sServiceAccount,
@@ -567,4 +567,11 @@ func segregateSourceAndProtos(dataRefs []string) (string, []string, []string) {
 		}
 	}
 	return sourceCode, validProto, InvalidFiles
+}
+
+func deprecatedCheck(ctx context.Context) {
+	if len(rconfig.DefaultFilesConfig.K8ServiceAccount) > 0 {
+		logger.Warning(ctx, "--K8ServiceAccount is deprecated, Please use --K8sServiceAccount")
+		rconfig.DefaultFilesConfig.K8sServiceAccount = rconfig.DefaultFilesConfig.K8ServiceAccount
+	}
 }

--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -55,21 +55,7 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-var FlyteSnacksRelease []FlyteSnack
 var Client *storage.DataStore
-
-// FlyteSnack Defines flyte test manifest structure
-type FlyteSnack struct {
-	Name          string    `json:"name"`
-	Priority      string    `json:"priority"`
-	Path          string    `json:"path"`
-	ExitCondition Condition `json:"exitCondition"`
-}
-
-type Condition struct {
-	ExitSuccess bool   `json:"exit_success"`
-	ExitMessage string `json:"exit_message"`
-}
 
 var httpClient HTTPClient
 
@@ -242,12 +228,12 @@ func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string) error {
 
 func hydrateLaunchPlanSpec(lpSpec *admin.LaunchPlanSpec) {
 	assumableIamRole := len(rconfig.DefaultFilesConfig.AssumableIamRole) > 0
-	k8ServiceAcct := len(rconfig.DefaultFilesConfig.K8ServiceAccount) > 0
+	k8ServiceAcct := len(rconfig.DefaultFilesConfig.K8sServiceAccount) > 0
 	outputLocationPrefix := len(rconfig.DefaultFilesConfig.OutputLocationPrefix) > 0
 	if assumableIamRole || k8ServiceAcct {
 		lpSpec.AuthRole = &admin.AuthRole{
 			AssumableIamRole:         rconfig.DefaultFilesConfig.AssumableIamRole,
-			KubernetesServiceAccount: rconfig.DefaultFilesConfig.K8ServiceAccount,
+			KubernetesServiceAccount: rconfig.DefaultFilesConfig.K8sServiceAccount,
 		}
 	}
 	if outputLocationPrefix {
@@ -468,32 +454,34 @@ func getJSONSpec(message proto.Message) string {
 	return jsonSpec
 }
 
-func getFlyteTestManifest(org, repository string) ([]FlyteSnack, string, error) {
+func filterExampleFromRelease(releases github.RepositoryRelease) []github.ReleaseAsset {
+	var assets []github.ReleaseAsset
+	for _, v := range releases.Assets {
+		if strings.HasSuffix(*v.Name, ".tgz") {
+			assets = append(assets, v)
+		}
+	}
+	return assets
+}
+
+func getAllFlytesnacksExample(org, repository, release string) ([]github.ReleaseAsset, string, error) {
 	c := github.NewClient(nil)
 	opt := &github.ListOptions{Page: 1, PerPage: 1}
+	if len(release) > 0 {
+		releases, _, err := c.Repositories.GetReleaseByTag(context.Background(), org, repository, release)
+		if err != nil {
+			return nil, "", err
+		}
+		return filterExampleFromRelease(*releases), release, nil
+	}
 	releases, _, err := c.Repositories.ListReleases(context.Background(), org, repository, opt)
 	if err != nil {
 		return nil, "", err
 	}
 	if len(releases) == 0 {
-		return nil, "", fmt.Errorf("Repository doesn't have any release")
+		return nil, "", fmt.Errorf("repository doesn't have any release")
 	}
-	response, err := http.Get(fmt.Sprintf(flyteManifest, *releases[0].TagName))
-	if err != nil {
-		return nil, "", err
-	}
-	defer response.Body.Close()
-
-	data, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, "", err
-	}
-
-	err = json.Unmarshal(data, &FlyteSnacksRelease)
-	if err != nil {
-		return nil, "", err
-	}
-	return FlyteSnacksRelease, *releases[0].TagName, nil
+	return filterExampleFromRelease(*releases[0]), release, nil
 
 }
 

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -278,7 +278,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole"}, lpSpec.AuthRole)
 	})
-	t.Run("k8Service account override", func(t *testing.T) {
+	t.Run("k8sService account override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
@@ -286,7 +286,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
 	})
-	t.Run("Both k8Service and IamRole", func(t *testing.T) {
+	t.Run("Both k8sService and IamRole", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -364,8 +364,8 @@ func TestGetAllFlytesnacksExample(t *testing.T) {
 	})
 	t.Run("Successfully get examples", func(t *testing.T) {
 		assets, tag, err := getAllFlytesnacksExample("flyteorg", "flytesnacks", "v0.2.175")
-		assert.NotNil(t, err)
-		assert.Equal(t, len(tag), 0)
+		assert.Nil(t, err)
+		assert.Greater(t, len(tag), 0)
 		assert.Greater(t, len(assets), 0)
 	})
 }

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -53,7 +53,7 @@ func registerFilesSetup() {
 	cmdCtx = cmdCore.NewCommandContext(mockAdminClient, u.MockOutStream)
 
 	rconfig.DefaultFilesConfig.AssumableIamRole = ""
-	rconfig.DefaultFilesConfig.K8ServiceAccount = ""
+	rconfig.DefaultFilesConfig.K8sServiceAccount = ""
 	rconfig.DefaultFilesConfig.OutputLocationPrefix = ""
 }
 
@@ -281,7 +281,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("k8Service account override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.K8ServiceAccount = "k8Account"
+		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
@@ -290,7 +290,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
-		rconfig.DefaultFilesConfig.K8ServiceAccount = "k8Account"
+		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole",
@@ -304,13 +304,6 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.RawOutputDataConfig{OutputLocationPrefix: "prefix"}, lpSpec.RawOutputDataConfig)
 	})
-}
-
-func TestFlyteManifest(t *testing.T) {
-	_, tag, err := getFlyteTestManifest(githubOrg, githubRepository)
-	assert.Nil(t, err)
-	assert.Contains(t, tag, "v")
-	assert.NotEmpty(t, tag)
 }
 
 func TestUploadFastRegisterArtifact(t *testing.T) {
@@ -358,22 +351,22 @@ func TestGetStorageClient(t *testing.T) {
 	})
 }
 
-func TestGetFlyteTestManifest(t *testing.T) {
+func TestGetAllFlytesnacksExample(t *testing.T) {
 	t.Run("Failed to get manifest with wrong name", func(t *testing.T) {
-		_, tag, err := getFlyteTestManifest("no////ne", "no////ne")
+		_, tag, err := getAllFlytesnacksExample("no////ne", "no////ne", "")
 		assert.NotNil(t, err)
 		assert.Equal(t, len(tag), 0)
 	})
 	t.Run("Failed to get release", func(t *testing.T) {
-		_, tag, err := getFlyteTestManifest("flyteorg", "homebrew-tap")
+		_, tag, err := getAllFlytesnacksExample("flyteorg", "homebrew-tap", "")
 		assert.NotNil(t, err)
 		assert.Equal(t, len(tag), 0)
 	})
-	t.Run("Failed to get manifest", func(t *testing.T) {
-		flyteManifest = ""
-		_, tag, err := getFlyteTestManifest("flyteorg", "flytesnacks")
+	t.Run("Successfully get examples", func(t *testing.T) {
+		assets, tag, err := getAllFlytesnacksExample("flyteorg", "flytesnacks", "v0.2.175")
 		assert.NotNil(t, err)
 		assert.Equal(t, len(tag), 0)
+		assert.Greater(t, len(assets), 0)
 	})
 }
 


### PR DESCRIPTION
# TL;DR
- Fix typo `K8sServiceAccount`
- Migrate register example from flyte-test-manifest to GitHub client 
- Added argument for passing release version in flytectl register
- Now flytectl register example will use GitHub tag as version


```bash
$ flytectl register examples  -d development  -p flytesnacks --k8sServiceAccount=demo
$ flytectl register examples  -d development  -p flytesnacks v0.2.174 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| NAME (9)                                                                                                                                                                                              | STATUS  | ADDITIONAL INFO |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/0_house_price_prediction.house_price_predictor.generate_and_split_data_1.pb                                       | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/1_house_price_prediction.house_price_predictor.fit_1.pb                                                           | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/2_house_price_prediction.house_price_predictor.predict_1.pb                                                       | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/3_house_price_prediction.house_price_predictor.house_price_predictor_trainer_2.pb                                 | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/4_house_price_prediction.house_price_predictor.house_price_predictor_trainer_3.pb                                 | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/5_house_price_prediction.multiregion_house_price_predictor.generate_and_split_data_multiloc_1.pb                  | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/6_house_price_prediction.multiregion_house_price_predictor.parallel_fit_predict_1.pb                              | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/7_house_price_prediction.multiregion_house_price_predictor.multi_region_house_price_prediction_model_trainer_2.pb | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
| /tmp/register516014713/./case_studies/ml_training/house_price_prediction/_pb_output/8_house_price_prediction.multiregion_house_price_predictor.multi_region_house_price_prediction_model_trainer_3.pb | Success | AlreadyExists   |
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- --------- -----------------
```

Usages
```
Registers all latest flytesnacks example
::

 bin/flytectl register examples  -d development  -p flytesnacks


Usage

Usage:
  flytectl register examples [flags]

Aliases:
  examples, example, flytesnack, flytesnacks

Flags:
      --archive                       pass in archive file either an http link or local path.
      --assumableIamRole string        custom assumable iam auth role to register launch plans with.
      --continueOnError               continue on error when registering files.
      --dryRun                        execute command without making any modifications.
  -h, --help                          help for examples
      --k8ServiceAccount string        custom kubernetes service account auth role to register launch plans with.
      --outputLocationPrefix string    custom output location prefix for offloaded types (files/schemas).
      --sourceUploadPath string        Location for source code in storage.
      --version string                version of the entity to be registered with flyte. (default "v1")

```
## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1404
https://github.com/flyteorg/flyte/issues/1410
https://github.com/flyteorg/flyte/issues/1405


## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
