### PR TITLE
Fix panic in rendering LP input descriptions 

### DIFF
--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -129,7 +129,7 @@ func LaunchplanToTableProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 	for _, m := range l {
 		m := proto.Clone(m).(*admin.LaunchPlan)
 		if m.Closure != nil {
-			if m.Closure.ExpectedInputs != nil {
+			if m.Closure.ExpectedInputs != nil && m.Closure.ExpectedInputs.Parameters != nil {
 				printer.FormatParameterDescriptions(m.Closure.ExpectedInputs.Parameters)
 			}
 			if m.Closure.ExpectedOutputs != nil && m.Closure.ExpectedOutputs.Variables != nil {


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Fix panic: assignment to entry in nil map for rendering launch plan descriptions. The method to format parameter descriptions actually assigns a specific value to a designated key in the parameter map with the rendered descriptions which of course fails when there are no parameters.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
