### PR TITLE
Removing the start-node check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin
 _test
 ./config.yaml
 docs/build/*
+cmd/upgrade/flyte.ext

--- a/cmd/get/node_execution.go
+++ b/cmd/get/node_execution.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"sort"
 	"strconv"
-	"strings"
 
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/printer"
@@ -149,10 +148,6 @@ func getNodeExecDetailsInt(ctx context.Context, project, domain, execName, nodeN
 				return nil, err
 			}
 		} else {
-			// Bug in admin https://github.com/flyteorg/flyte/issues/1221
-			if strings.HasSuffix(nodeExec.Id.NodeId, "start-node") {
-				continue
-			}
 			taskExecList, err := cmdCtx.AdminFetcherExt().FetchTaskExecutionsOnNode(ctx,
 				nodeExec.Id.NodeId, execName, project, domain)
 			if err != nil {
@@ -260,6 +255,9 @@ func createNodeDetailsTreeView(rootView gotree.Tree, nodeExecutionClosures []*No
 
 func extractLiteralMap(literalMap *core.LiteralMap) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
+	if literalMap == nil || literalMap.Literals == nil {
+		return m, nil
+	}
 	for key, literalVal := range literalMap.Literals {
 		extractedLiteralVal, err := coreutils.ExtractFromLiteral(literalVal)
 		if err != nil {

--- a/cmd/get/node_execution_test.go
+++ b/cmd/get/node_execution_test.go
@@ -312,3 +312,13 @@ func TestGetExecutionDetails(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("unable to fetch task exec details"), err)
 	})
 }
+
+func TestExtractLiteralMapError(t *testing.T) {
+	literalMap, err := extractLiteralMap(nil)
+	assert.Nil(t, err)
+	assert.Equal(t, len(literalMap), 0)
+
+	literalMap, err = extractLiteralMap(&core.LiteralMap{})
+	assert.Nil(t, err)
+	assert.Equal(t, len(literalMap), 0)
+}


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>


# TL;DR
* Removed the logic to avoid calling FetchTaskExecutionsOnNode on start-node
```
flytectl get execution  -p flytesnacks -d development fdac281aa2ba5484da2a --details -o json --nodeID start-node
[
	{
		"node_exec": {
			"id": {
				"nodeId": "start-node",
				"executionId": {
					"project": "flytesnacks",
					"domain": "development",
					"name": "fdac281aa2ba5484da2a"
				}
			},
			"inputUri": "s3://my-s3-bucket/metadata/propeller/sandbox/flytesnacks-development-fdac281aa2ba5484da2a/start-node/data/0/outputs.pb",
			"closure": {
				"outputUri": "s3://my-s3-bucket/metadata/propeller/sandbox/flytesnacks-development-fdac281aa2ba5484da2a/start-node/data/0/outputs.pb",
				"phase": "SUCCEEDED",
				"createdAt": "2021-09-13T05:22:21.982200Z",
				"updatedAt": "2021-09-13T05:22:21.982200Z"
			},
			"metadata": {
				"specNodeId": "start-node"
			}
		},
		"inputs": {
			"am": true,
			"day_of_week": "Sunday",
			"number": 5
		},
		"outputs": {
			"am": true,
			"day_of_week": "Sunday",
			"number": 5
		}
	}
]

```

* Added cmd/upgrade/flyte.ext to .gitignore
* Added nil checks in extractLiteralMap 

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1221
## Follow-up issue
_NA_

