### PR TITLE
added support for helm

### DIFF
--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -51,7 +51,6 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.StringVar(&DefaultConfig.Source, fmt.Sprintf("%v%v", prefix, "source"), DefaultConfig.Source, "Path of your source code")
-	cmdFlags.StringVar(&DefaultConfig.Image, fmt.Sprintf("%v%v", prefix, "image"), DefaultConfig.Image, "flyte sandbox custom image")
 	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -50,7 +50,8 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
-	cmdFlags.StringVar(&DefaultConfig.Source, fmt.Sprintf("%v%v", prefix, "source"), DefaultConfig.Source, " Path of your source code")
+	cmdFlags.StringVar(&DefaultConfig.Source, fmt.Sprintf("%v%v", prefix, "source"), DefaultConfig.Source, "Path of your source code")
+	cmdFlags.StringVar(&DefaultConfig.Image, fmt.Sprintf("%v%v", prefix, "image"), DefaultConfig.Image, "flyte sandbox custom image")
 	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -51,6 +51,6 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.StringVar(&DefaultConfig.Source, fmt.Sprintf("%v%v", prefix, "source"), DefaultConfig.Source, "Path of your source code")
-	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte")
+	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte. Only support v0.10.0+ flyte release")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -113,20 +113,6 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
-	t.Run("Test_image", func(t *testing.T) {
-
-		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
-
-			cmdFlags.Set("image", testValue)
-			if vString, err := cmdFlags.GetString("image"); err == nil {
-				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Image)
-
-			} else {
-				assert.FailNow(t, err.Error())
-			}
-		})
-	})
 	t.Run("Test_version", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -113,6 +113,20 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_image", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("image", testValue)
+			if vString, err := cmdFlags.GetString("image"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Image)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_version", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -2,11 +2,15 @@ package sandbox
 
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
-	DefaultConfig = &Config{}
+	DefaultConfig = &Config{
+		Image: "cr.flyte.org/flyteorg/flyte-sandbox",
+		Version: "dind",
+	}
 )
 
 //Config
 type Config struct {
 	Source  string `json:"source" pflag:",Path of your source code"`
+	Image  string `json:"image" pflag:",flyte sandbox custom image"`
 	Version string `json:"version" pflag:",Version of flyte"`
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -3,7 +3,7 @@ package sandbox
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
-		Version: "latest",
+		Version: "dind",
 	}
 )
 
@@ -13,5 +13,6 @@ type Config struct {
 
 	// Flytectl sandbox only support flyte version available in Github release https://github.com/flyteorg/flyte/tags
 	// Flytectl sandbox will only work for v0.10.0+
+	// Default value dind represent the latest release
 	Version string `json:"version" pflag:",Version of flyte. Only support v0.10.0+ flyte release"`
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -3,12 +3,15 @@ package sandbox
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
-		Version: "dind",
+		Version: "latest",
 	}
 )
 
 //Config
 type Config struct {
-	Source  string `json:"source" pflag:",Path of your source code"`
-	Version string `json:"version" pflag:",Version of flyte"`
+	Source string `json:"source" pflag:",Path of your source code"`
+
+	// Flytectl sandbox only support flyte version available in Github release https://github.com/flyteorg/flyte/tags
+	// Flytectl sandbox will only work for v0.10.0+
+	Version string `json:"version" pflag:",Version of flyte. Only support v0.10.0+ flyte release"`
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -2,9 +2,7 @@ package sandbox
 
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
-	DefaultConfig = &Config{
-		Version: "",
-	}
+	DefaultConfig = &Config{}
 )
 
 //Config

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -3,7 +3,6 @@ package sandbox
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
-		Image: "cr.flyte.org/flyteorg/flyte-sandbox",
 		Version: "dind",
 	}
 )
@@ -11,6 +10,5 @@ var (
 //Config
 type Config struct {
 	Source  string `json:"source" pflag:",Path of your source code"`
-	Image  string `json:"image" pflag:",flyte sandbox custom image"`
 	Version string `json:"version" pflag:",Version of flyte"`
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -3,7 +3,7 @@ package sandbox
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
-		Version: "dind",
+		Version: "",
 	}
 )
 

--- a/cmd/sandbox/sandbox.go
+++ b/cmd/sandbox/sandbox.go
@@ -56,7 +56,7 @@ func CreateSandboxCommand() *cobra.Command {
 			Long:  statusLong},
 		"exec": {CmdFunc: sandboxClusterExec, Aliases: []string{}, ProjectDomainNotRequired: true,
 			Short: execShort,
-			Long:  execLong, PFlagProvider: sandboxConfig.DefaultConfig},
+			Long:  execLong},
 	}
 
 	cmdcore.AddCommands(sandbox, sandboxResourcesFuncs)

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -44,7 +44,7 @@ Mount your source code repository inside sandbox
 
  bin/flytectl sandbox start --source=$HOME/flyteorg/flytesnacks 
 	
-Run specific version of flyte, Only available after v0.13.0+
+Run specific version of flyte
 ::
 
  bin/flytectl sandbox start  --version=v0.14.0

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -133,7 +133,8 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 		volumes = append(volumes, *vol)
 	}
 
-	if sandboxConfig.DefaultConfig.Version != dind {
+	var tag = "dind"
+	if len(sandboxConfig.DefaultConfig.Version) > 0 {
 		isGreater, err := util.IsVersionGreaterThan(sandboxConfig.DefaultConfig.Version, sandboxSupportedVersion)
 		if err != nil {
 			return nil, err
@@ -145,12 +146,12 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 		if err != nil {
 			return nil, err
 		}
-		sandboxConfig.DefaultConfig.Version = fmt.Sprintf("%s-%s", dind, sha)
+		tag = fmt.Sprintf("%s-%s", dind, sha)
 	}
 
 	// Latest release will use image cr.flyte.org/flyteorg/flyte-sandbox:dind
 	// In case of version flytectl will use cr.flyte.org/flyteorg/flyte-sandbox:dind-{SHA}
-	var sandboxImageName = fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version)
+	var sandboxImageName = fmt.Sprintf("%s:%s", docker.ImageName, tag)
 
 	fmt.Printf("%v pulling docker image for release %s\n", emoji.Whale, sandboxImageName)
 	if err := docker.PullDockerImage(ctx, cli, sandboxImageName); err != nil {

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -136,9 +136,9 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 		sandboxConfig.DefaultConfig.Version = fmt.Sprintf("%s-%s", flyteTag, sha)
 	}
 
-	var sandboxImageName = fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version)
+	var sandboxImageName = fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version)
 
-	fmt.Printf("%v pulling docker image for release %s\n", emoji.Whale, sandboxConfig.DefaultConfig.Image)
+	fmt.Printf("%v pulling docker image for release %s\n", emoji.Whale, docker.ImageName)
 	if err := docker.PullDockerImage(ctx, cli, sandboxImageName); err != nil {
 		return nil, err
 	}

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -164,14 +164,14 @@ func getSandboxImage(version string) (string, error) {
 
 	var tag = dind
 	if len(version) > 0 {
-		isGreater, err := util.IsVersionGreaterThan(sandboxConfig.DefaultConfig.Version, sandboxSupportedVersion)
+		isGreater, err := util.IsVersionGreaterThan(version, sandboxSupportedVersion)
 		if err != nil {
 			return "", err
 		}
 		if !isGreater {
 			return "", fmt.Errorf("version flag only supported with flyte %s+ release", sandboxSupportedVersion)
 		}
-		sha, err := githubutil.GetSHAFromVersion(sandboxConfig.DefaultConfig.Version, flyteRepository)
+		sha, err := githubutil.GetSHAFromVersion(version, flyteRepository)
 		if err != nil {
 			return "", err
 		}

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -90,7 +90,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -120,7 +120,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -165,7 +165,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -204,7 +204,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -241,7 +241,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:dind-%s", sandboxConfig.DefaultConfig.Image, sha),
+			Image:        fmt.Sprintf("%s:dind-%s", docker.ImageName, sha),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -274,7 +274,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -312,7 +312,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -349,7 +349,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -389,7 +389,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = ""
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -426,7 +426,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -464,7 +464,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -507,7 +507,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -544,7 +544,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", sandboxConfig.DefaultConfig.Image, sandboxConfig.DefaultConfig.Version),
+			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -692,4 +692,12 @@ func TestGetSandboxImage(t *testing.T) {
 		_, err := getSandboxImage("v100.1.0")
 		assert.NotNil(t, err)
 	})
+	t.Run("Get sandbox image with wrong version ", func(t *testing.T) {
+		_, err := getSandboxImage("aaaaaa")
+		assert.NotNil(t, err)
+	})
+	t.Run("Get sandbox image with version that is not supported", func(t *testing.T) {
+		_, err := getSandboxImage("v0.10.0")
+		assert.NotNil(t, err)
+	})
 }

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -74,10 +74,6 @@ var fakePod = corev1.Pod{
 	},
 }
 
-func sandboxImage(tag string) string {
-	return fmt.Sprintf("%s:%s", docker.ImageName, tag)
-}
-
 func TestStartSandboxFunc(t *testing.T) {
 	p1, p2, _ := docker.GetSandboxPorts()
 	assert.Nil(t, util.SetupFlyteDir())
@@ -91,10 +87,11 @@ func TestStartSandboxFunc(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
+		sandboxConfig.DefaultConfig.Version = ""
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -124,7 +121,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -161,7 +158,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
-		sandboxConfig.DefaultConfig.Version = dind
+		sandboxConfig.DefaultConfig.Version = ""
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -170,7 +167,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -199,7 +196,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = "../"
-		sandboxConfig.DefaultConfig.Version = dind
+		sandboxConfig.DefaultConfig.Version = ""
 		absPath, err := filepath.Abs(sandboxConfig.DefaultConfig.Source)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
@@ -210,7 +207,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -247,7 +244,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(fmt.Sprintf("%s-%s", dind, sha)),
+			Image:        docker.GetSandboxImage(fmt.Sprintf("%s-%s", dind, sha)),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -280,7 +277,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -318,7 +315,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -355,7 +352,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -395,7 +392,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = ""
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -432,7 +429,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -461,7 +458,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
-		sandboxConfig.DefaultConfig.Version = dind
+		sandboxConfig.DefaultConfig.Version = ""
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -470,7 +467,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -513,7 +510,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -537,7 +534,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		docker.Client = mockDocker
 		sandboxConfig.DefaultConfig.Source = ""
-		sandboxConfig.DefaultConfig.Version = dind
+		sandboxConfig.DefaultConfig.Version = ""
 		err = startSandboxCluster(ctx, []string{}, cmdCtx)
 		assert.Nil(t, err)
 	})
@@ -550,7 +547,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        sandboxImage(dind),
+			Image:        docker.GetSandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -30,8 +30,6 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
-const latest = "latest"
-
 var content = `
 apiVersion: v1
 clusters:
@@ -163,7 +161,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
-		sandboxConfig.DefaultConfig.Version = latest
+		sandboxConfig.DefaultConfig.Version = dind
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -201,7 +199,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = "../"
-		sandboxConfig.DefaultConfig.Version = latest
+		sandboxConfig.DefaultConfig.Version = dind
 		absPath, err := filepath.Abs(sandboxConfig.DefaultConfig.Source)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
@@ -463,7 +461,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
-		sandboxConfig.DefaultConfig.Version = latest
+		sandboxConfig.DefaultConfig.Version = dind
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -539,7 +537,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		docker.Client = mockDocker
 		sandboxConfig.DefaultConfig.Source = ""
-		sandboxConfig.DefaultConfig.Version = latest
+		sandboxConfig.DefaultConfig.Version = dind
 		err = startSandboxCluster(ctx, []string{}, cmdCtx)
 		assert.Nil(t, err)
 	})

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -675,3 +675,21 @@ func TestGetNodeTaintStatus(t *testing.T) {
 		assert.Equal(t, true, c)
 	})
 }
+
+func TestGetSandboxImage(t *testing.T) {
+	t.Run("Get Latest sandbox", func(t *testing.T) {
+		image, err := getSandboxImage("")
+		assert.Nil(t, err)
+		assert.Equal(t, docker.GetSandboxImage(dind), image)
+	})
+
+	t.Run("Get sandbox image with version ", func(t *testing.T) {
+		image, err := getSandboxImage("v0.14.0")
+		assert.Nil(t, err)
+		assert.Equal(t, true, strings.HasPrefix(image, docker.ImageName))
+	})
+	t.Run("Get sandbox image with wrong version ", func(t *testing.T) {
+		_, err := getSandboxImage("v100.1.0")
+		assert.NotNil(t, err)
+	})
+}

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -30,6 +30,8 @@ import (
 	testclient "k8s.io/client-go/kubernetes/fake"
 )
 
+const latest = "latest"
+
 var content = `
 apiVersion: v1
 clusters:
@@ -74,6 +76,10 @@ var fakePod = corev1.Pod{
 	},
 }
 
+func sandboxImage(tag string) string {
+	return fmt.Sprintf("%s:%s", docker.ImageName, tag)
+}
+
 func TestStartSandboxFunc(t *testing.T) {
 	p1, p2, _ := docker.GetSandboxPorts()
 	assert.Nil(t, util.SetupFlyteDir())
@@ -90,7 +96,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -120,7 +126,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -157,6 +163,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
+		sandboxConfig.DefaultConfig.Version = latest
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -165,7 +172,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -194,6 +201,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = "../"
+		sandboxConfig.DefaultConfig.Version = latest
 		absPath, err := filepath.Abs(sandboxConfig.DefaultConfig.Source)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
@@ -204,7 +212,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -241,7 +249,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:dind-%s", docker.ImageName, sha),
+			Image:        sandboxImage(fmt.Sprintf("%s-%s", dind, sha)),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -274,7 +282,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -312,7 +320,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -349,7 +357,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -389,7 +397,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = ""
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -426,7 +434,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -455,7 +463,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
-		sandboxConfig.DefaultConfig.Version = "dind"
+		sandboxConfig.DefaultConfig.Version = latest
 		volumes := docker.Volumes
 		volumes = append(volumes, mount.Mount{
 			Type:   mount.TypeBind,
@@ -464,7 +472,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		})
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -507,7 +515,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{
@@ -531,7 +539,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 		docker.Client = mockDocker
 		sandboxConfig.DefaultConfig.Source = ""
-		sandboxConfig.DefaultConfig.Version = "dind"
+		sandboxConfig.DefaultConfig.Version = latest
 		err = startSandboxCluster(ctx, []string{}, cmdCtx)
 		assert.Nil(t, err)
 	})
@@ -544,7 +552,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
-			Image:        fmt.Sprintf("%s:%s", docker.ImageName, sandboxConfig.DefaultConfig.Version),
+			Image:        sandboxImage(dind),
 			Tty:          false,
 			ExposedPorts: p1,
 		}, &container.HostConfig{

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -179,3 +179,8 @@ func InspectExecResp(ctx context.Context, cli Docker, containerID string) error 
 	}
 	return nil
 }
+
+// GetSandboxImage will return the sandbox image with tag
+func GetSandboxImage(tag string) string {
+	return fmt.Sprintf("%s:%s", ImageName, tag)
+}

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -24,7 +24,7 @@ import (
 var (
 	Kubeconfig              = f.FilePathJoin(f.UserHomeDir(), ".flyte", "k3s", "k3s.yaml")
 	SuccessMessage          = "Deploying Flyte..."
-	ImageName               = "cr.flyte.org/flyteorg/flyte-sandbox:dind"
+	ImageName               = "cr.flyte.org/flyteorg/flyte-sandbox"
 	FlyteSandboxClusterName = "flyte-sandbox"
 	Environment             = []string{"SANDBOX=1", "KUBERNETES_API_PORT=30086", "FLYTE_HOST=localhost:30081", "FLYTE_AWS_ENDPOINT=http://localhost:30084"}
 	Source                  = "/root"

--- a/pkg/util/githubutil/githubutil.go
+++ b/pkg/util/githubutil/githubutil.go
@@ -2,6 +2,7 @@ package githubutil
 
 import (
 	"context"
+	"net/http"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -46,9 +47,14 @@ var (
 	arch = platformutil.Arch(runtime.GOARCH)
 )
 
+//GetGHClient will return github client
+func GetGHClient() *github.Client {
+	return github.NewClient(&http.Client{})
+}
+
 // GetLatestVersion returns the latest version of provided repository
 func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
-	client := github.NewClient(nil)
+	client := GetGHClient()
 	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
 	if err != nil {
 		return nil, err
@@ -67,7 +73,7 @@ func getFlytectlAssetName() string {
 
 // CheckVersionExist returns the provided version release if version exist in repository
 func CheckVersionExist(version, repository string) (*github.RepositoryRelease, error) {
-	client := github.NewClient(nil)
+	client := GetGHClient()
 	release, _, err := client.Repositories.GetReleaseByTag(context.Background(), owner, repository, version)
 	if err != nil {
 		return nil, err
@@ -77,7 +83,7 @@ func CheckVersionExist(version, repository string) (*github.RepositoryRelease, e
 
 // GetSHAFromVersion returns sha commit hash against a release
 func GetSHAFromVersion(version, repository string) (string, error) {
-	client := github.NewClient(nil)
+	client := GetGHClient()
 	sha, _, err := client.Repositories.GetCommitSHA1(context.Background(), owner, repository, version, "")
 	if err != nil {
 		return "", err

--- a/pkg/util/githubutil/githubutil_test.go
+++ b/pkg/util/githubutil/githubutil_test.go
@@ -42,6 +42,18 @@ func TestCheckVersionExist(t *testing.T) {
 	})
 }
 
+func TestGetSHAFromVersion(t *testing.T) {
+	t.Run("Invalid Tag", func(t *testing.T) {
+		_, err := GetSHAFromVersion("v100.0.0", "flyte")
+		assert.NotNil(t, err)
+	})
+	t.Run("Valid Tag", func(t *testing.T) {
+		release, err := GetSHAFromVersion("v0.15.0", "flyte")
+		assert.Nil(t, err)
+		assert.Greater(t, len(release), 0)
+	})
+}
+
 func TestGetAssetsFromRelease(t *testing.T) {
 	t.Run("Successful get assets", func(t *testing.T) {
 		assets, err := GetAssetsFromRelease("v0.15.0", sandboxManifest, flyte)
@@ -59,21 +71,6 @@ func TestGetAssetsFromRelease(t *testing.T) {
 		assets, err := GetAssetsFromRelease("v100.15.0", "test", flyte)
 		assert.NotNil(t, err)
 		assert.Nil(t, assets)
-	})
-}
-
-func TestGetFlyteManifest(t *testing.T) {
-	t.Run("Successful get manifest", func(t *testing.T) {
-		err := GetFlyteManifest("v0.15.0", "test.yaml")
-		assert.Nil(t, err)
-	})
-	t.Run("Failed get manifest with wrong name", func(t *testing.T) {
-		err := GetFlyteManifest("v100.15.0", "test.yaml")
-		assert.NotNil(t, err)
-	})
-	t.Run("Failed get manifest with wrong name", func(t *testing.T) {
-		err := GetFlyteManifest("v0.12.0", "test.yaml")
-		assert.NotNil(t, err)
 	})
 }
 


### PR DESCRIPTION
# TL;DR
- Added support for version, Started using docker images with tag

```
flytectl sandbox start --version=v0.17.0 
🧑‍🏭 Bootstrapping a brand new flyte cluster... 🔨 🔧
delete existing sandbox cluster [y/n]: y
🐋 pulling docker image for release cr.flyte.org/flyteorg/flyte-sandbox
{"status":"Pulling from flyteorg/flyte-sandbox","id":"dind-cb658c8b20a1505021157570c122b2040173f2b5"}

flytectl sandbox start --version=v0.10.0 
🧑‍🏭 Bootstrapping a brand new flyte cluster... 🔨 🔧
Error: version flag only supported with flyte v0.10.0+ release
exit status 1

```
## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1430


## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
