### PR TITLE
flytectl sandbox start --image xyz

### DIFF
--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -51,6 +51,7 @@ func (Config) mustMarshalJSON(v json.Marshaler) string {
 func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("Config", pflag.ExitOnError)
 	cmdFlags.StringVar(&DefaultConfig.Source, fmt.Sprintf("%v%v", prefix, "source"), DefaultConfig.Source, "Path of your source code")
-	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte. Only support v0.10.0+ flyte release")
+	cmdFlags.StringVar(&DefaultConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultConfig.Version, "Version of flyte. Only supports flyte releases greater than v0.10.0")
+	cmdFlags.StringVar(&DefaultConfig.Image, fmt.Sprintf("%v%v", prefix, "image"), DefaultConfig.Image, "Optional. Provide a fully qualified path to a Flyte compliant docker image.")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -127,4 +127,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_image", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("image", testValue)
+			if vString, err := cmdFlags.GetString("image"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Image)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -9,8 +9,13 @@ var (
 type Config struct {
 	Source string `json:"source" pflag:",Path of your source code"`
 
-	// Flytectl sandbox only support flyte version available in Github release https://github.com/flyteorg/flyte/tags
+	// Flytectl sandbox only supports flyte version available in Github release https://github.com/flyteorg/flyte/tags
 	// Flytectl sandbox will only work for v0.10.0+
-	// Default value dind represent the latest release
-	Version string `json:"version" pflag:",Version of flyte. Only support v0.10.0+ flyte release"`
+	// Default value dind represents the latest release
+	Version string `json:"version" pflag:",Version of flyte. Only supports flyte releases greater than v0.10.0"`
+
+	// Optionally it is possible to specify a specific fqn for the docker image with the tag. This should be
+	// Flyte compliant sandbox image. Usually useful, if you want to push the image to your own registry and relaunch
+	// from there.
+	Image string `json:"image" pflag:",Optional. Provide a fully qualified path to a Flyte compliant docker image."`
 }

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -49,10 +49,15 @@ Run specific version of flyte. flytectl sandbox only support flyte version avail
 
  bin/flytectl sandbox start  --version=v0.14.0
 
-Note: Flytectl sandbox will only work for v0.10.0+
-	
+Note: Flytectl sandbox is only supported for Flyte versions > v0.10.0
+
+Specify a Flyte Sandbox compliant image with the registry. This is useful, in case you want to use an image from your registry.
+::
+
+  flytectl 
+
 Usage
-	`
+`
 	k8sEndpoint             = "https://127.0.0.1:30086"
 	flyteNamespace          = "flyte"
 	flyteRepository         = "flyte"
@@ -133,7 +138,7 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 		volumes = append(volumes, *vol)
 	}
 
-	image, err := getSandboxImage(sandboxConfig.DefaultConfig.Version)
+	image, err := getSandboxImage(sandboxConfig.DefaultConfig.Version, sandboxConfig.DefaultConfig.Image)
 	if err != nil {
 		return nil, err
 	}
@@ -158,9 +163,13 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	return logReader, nil
 }
 
-func getSandboxImage(version string) (string, error) {
+func getSandboxImage(version string, alternateImage string) (string, error) {
 	// Latest release will use image cr.flyte.org/flyteorg/flyte-sandbox:dind
 	// In case of version flytectl will use cr.flyte.org/flyteorg/flyte-sandbox:dind-{SHA}
+
+	if len(alternateImage) > 0 {
+		return alternateImage, nil
+	}
 
 	var tag = dind
 	if len(version) > 0 {


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
Sandbox can now use a custom image

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [x] Any pending items have an associated Issue

## Complete description
`flytectl sandbox start --image docker.io/xyz:v1` is now supported. This helps in pulling images from blessed registries

## Tracking Issue
fixes: https://github.com/flyteorg/flyte/issues/1578

## Follow-up issue
NA
