### PR TITLE
Workflow: Do not bump version and consequently release on docs or boilerplate update

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,18 +4,20 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - "docs/**"
+      - "boilerplate/**"
 
 jobs:
   bump-version:
     name: Bump Version
-    if: github.event.head_commit.name != 'flyte-bot'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
       - name: Bump version and push tag
         id: bump-version
         uses: anothrNick/github-tag-action@1.17.2


### PR DESCRIPTION
Instead of checking whether the committer is the flyte-bot, we add the docs and boilerplate directories to the ignored paths list. Thus, if all changed files reside in the ignored directories, the version is not bumped and consequently the release workflow is not run.

### Type

N/A

### Are all requirements met?

N/A

### Tracking Issue
Fixes https://github.com/flyteorg/flyte/issues/1621