### PR TITLE
Added minio port in sandbox

### DIFF
--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -78,10 +78,10 @@ func RemoveSandbox(ctx context.Context, cli Docker, reader io.Reader) error {
 // GetSandboxPorts will return sandbox ports
 func GetSandboxPorts() (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
 	return nat.ParsePortSpecs([]string{
-		"0.0.0.0:30086:30086", // K8s Dashboard Port
 		"0.0.0.0:30081:30081", // Flyteconsole Port
 		"0.0.0.0:30082:30082", // Flyteadmin Port
 		"0.0.0.0:30084:30084", // Minio API Port
+		"0.0.0.0:30086:30086", // K8s Dashboard Port
 		"0.0.0.0:30087:30087", // Minio Console Port
 	})
 }


### PR DESCRIPTION
# TL;DR
- Added Minio port in the sandbox. After https://github.com/flyteorg/flyte/pull/1681 we added a new port for the Minio console

We can merge it after flyte v0.18.0 patch release

Testing
- For now, I upgrade the helm chart from the master branch 

![Screenshot 2021-10-19 at 9 10 19 PM](https://user-images.githubusercontent.com/10830562/137945038-42c6e751-bf22-4fc7-af8e-6805922361c1.png)

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
