### PR TITLE
Added M1 support 

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,8 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+universal_binaries:
+  - replace: false
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flyteorg/flytectl
 
-go 1.13
+go 1.16
 
 require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,7 +281,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=


### PR DESCRIPTION
# TL;DR
- Added darwin universal binary for amd64 & arm64, It will produce 3 binaries `amd64/arm64/all`

Ref: https://goreleaser.com/customization/universalbinaries/

Test Result : https://github.com/flyteorg/flytectl/runs/3972486591?check_suite_focus=true#step:5:85


## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [x] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
