### PR TITLE
Fix: fixes unhelpful error message on flytectl register

### DIFF
--- a/cmd/register/files.go
+++ b/cmd/register/files.go
@@ -96,6 +96,11 @@ func registerFromFilesFunc(ctx context.Context, args []string, cmdCtx cmdCore.Co
 }
 
 func Register(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
+  n, err := filepath.Glob(args[0]);
+  if n == nil || err != nil {
+		return fmt.Errorf(args[0]+" is empty or does not exist. You may have forgotten to run \"make serialize\"")
+  }
+
 	var regErr error
 	var dataRefs []string
 


### PR DESCRIPTION
This  PR asks the user to run `make serialize` if the `user-provided` directory is empty when `register` is run without `serializing`.
Might fix flyteorg/flyte#1550

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested (not needed)
- [ ] Unit tests added (not needed)
- [ ] Code documentation added (not needed)
- [x] Any pending items have an associated Issue

## Complete description
When `register` is run, if  `_pb_output` is  empty, an error is raised asking the user to run `make serialize`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1550