### PR TITLE
[Housekeeping] Refactor flytectl flags

### DIFF
--- a/cmd/register/examples.go
+++ b/cmd/register/examples.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-github/github"
 
-	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 )
 
@@ -51,8 +50,8 @@ func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.Com
 	}
 
 	logger.Infof(ctx, "Register started for %s %s release https://github.com/%s/%s/releases/tag/%s", flytesnacksRepository, tag, githubOrg, flytesnacksRepository, tag)
-	rconfig.DefaultFilesConfig.Archive = true
-	rconfig.DefaultFilesConfig.Version = tag
+	defaultFilesConfig.Archive = true
+	defaultFilesConfig.Version = tag
 	for _, v := range examples {
 		args := []string{
 			*v.BrowserDownloadURL,

--- a/cmd/register/examples.go
+++ b/cmd/register/examples.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-github/github"
 
+	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 )
 
@@ -39,7 +40,7 @@ func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.Com
 	var release string
 
 	// Deprecated checks for --k8Service
-	deprecatedCheck(ctx)
+	deprecatedCheck(ctx, &rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.K8ServiceAccount)
 
 	if len(args) == 1 {
 		release = args[0]
@@ -50,8 +51,8 @@ func registerExamplesFunc(ctx context.Context, args []string, cmdCtx cmdCore.Com
 	}
 
 	logger.Infof(ctx, "Register started for %s %s release https://github.com/%s/%s/releases/tag/%s", flytesnacksRepository, tag, githubOrg, flytesnacksRepository, tag)
-	defaultFilesConfig.Archive = true
-	defaultFilesConfig.Version = tag
+	rconfig.DefaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Version = tag
 	for _, v := range examples {
 		args := []string{
 			*v.BrowserDownloadURL,

--- a/cmd/register/files.go
+++ b/cmd/register/files.go
@@ -89,7 +89,10 @@ Override Output location prefix during registration.
 Usage
 `
 	sourceCodeExtension = ".tar.gz"
+	
 )
+
+var defaultFilesConfig = rconfig.DefaultFilesConfig
 
 func registerFromFilesFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
 	return Register(ctx, args, cmdCtx)

--- a/cmd/register/files.go
+++ b/cmd/register/files.go
@@ -126,14 +126,14 @@ func Register(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext)
 	if len(sourceCode) > 0 {
 		logger.Infof(ctx, "Fast Registration detected")
 		_, sourceCodeName = filepath.Split(sourceCode)
-		if err = uploadFastRegisterArtifact(ctx, sourceCode, sourceCodeName, rconfig.DefaultFilesConfig.Version); err != nil {
+		if err = uploadFastRegisterArtifact(ctx, sourceCode, sourceCodeName, defaultFilesConfig.Version); err != nil {
 			return fmt.Errorf("please check your Storage Config. It failed while uploading the source code. %v", err)
 		}
-		logger.Infof(ctx, "Source code successfully uploaded %v/%v ", rconfig.DefaultFilesConfig.SourceUploadPath, sourceCodeName)
+		logger.Infof(ctx, "Source code successfully uploaded %v/%v ", defaultFilesConfig.SourceUploadPath, sourceCodeName)
 	}
 
 	var registerResults []Result
-	fastFail := rconfig.DefaultFilesConfig.ContinueOnError
+	fastFail := defaultFilesConfig.ContinueOnError
 	for i := 0; i < len(validProto) && !(fastFail && regErr != nil); i++ {
 		registerResults, regErr = registerFile(ctx, validProto[i], sourceCodeName, registerResults, cmdCtx)
 	}

--- a/cmd/register/files_test.go
+++ b/cmd/register/files_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flytestdlib/storage"
 
-	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
-
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -23,7 +21,7 @@ func TestRegisterFromFiles(t *testing.T) {
 	t.Run("Valid registration", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.Archive = true
+		defaultFilesConfig.Archive = true
 		args = []string{"testdata/valid-parent-folder-register.tar"}
 		mockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil, nil)
 		mockAdminClient.OnCreateWorkflowMatch(mock.Anything, mock.Anything).Return(nil, nil)
@@ -36,9 +34,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.Archive = true
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
-		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
+		defaultFilesConfig.Archive = true
+		defaultFilesConfig.OutputLocationPrefix = s3Output
+		defaultFilesConfig.SourceUploadPath = s3Output
 		mockStorage, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -58,8 +56,8 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		rconfig.DefaultFilesConfig.Archive = true
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
+		defaultFilesConfig.Archive = true
+		defaultFilesConfig.OutputLocationPrefix = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -77,8 +75,8 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		rconfig.DefaultFilesConfig.Archive = true
-		rconfig.DefaultFilesConfig.SourceUploadPath = ""
+		defaultFilesConfig.Archive = true
+		defaultFilesConfig.SourceUploadPath = ""
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -96,10 +94,10 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		rconfig.DefaultFilesConfig.Archive = true
+		defaultFilesConfig.Archive = true
 
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
-		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
+		defaultFilesConfig.OutputLocationPrefix = s3Output
+		defaultFilesConfig.SourceUploadPath = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -118,10 +116,10 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		rconfig.DefaultFilesConfig.Archive = true
+		defaultFilesConfig.Archive = true
 
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
-		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
+		defaultFilesConfig.OutputLocationPrefix = s3Output
+		defaultFilesConfig.SourceUploadPath = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -140,9 +138,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		rconfig.DefaultFilesConfig.Archive = false
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
-		rconfig.DefaultFilesConfig.SourceUploadPath = ""
+		defaultFilesConfig.Archive = false
+		defaultFilesConfig.OutputLocationPrefix = s3Output
+		defaultFilesConfig.SourceUploadPath = ""
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))

--- a/cmd/register/files_test.go
+++ b/cmd/register/files_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/flyteorg/flytestdlib/promutils/labeled"
 	"github.com/flyteorg/flytestdlib/storage"
 
+	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -21,7 +22,7 @@ func TestRegisterFromFiles(t *testing.T) {
 	t.Run("Valid registration", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		defaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.Archive = true
 		args = []string{"testdata/valid-parent-folder-register.tar"}
 		mockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil, nil)
 		mockAdminClient.OnCreateWorkflowMatch(mock.Anything, mock.Anything).Return(nil, nil)
@@ -34,9 +35,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
 		registerFilesSetup()
-		defaultFilesConfig.Archive = true
-		defaultFilesConfig.OutputLocationPrefix = s3Output
-		defaultFilesConfig.SourceUploadPath = s3Output
+		rconfig.DefaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
+		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
 		mockStorage, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -56,8 +57,8 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		defaultFilesConfig.Archive = true
-		defaultFilesConfig.OutputLocationPrefix = s3Output
+		rconfig.DefaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -75,8 +76,8 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		defaultFilesConfig.Archive = true
-		defaultFilesConfig.SourceUploadPath = ""
+		rconfig.DefaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.SourceUploadPath = ""
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -94,10 +95,10 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		defaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.Archive = true
 
-		defaultFilesConfig.OutputLocationPrefix = s3Output
-		defaultFilesConfig.SourceUploadPath = s3Output
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
+		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -116,10 +117,10 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		defaultFilesConfig.Archive = true
+		rconfig.DefaultFilesConfig.Archive = true
 
-		defaultFilesConfig.OutputLocationPrefix = s3Output
-		defaultFilesConfig.SourceUploadPath = s3Output
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
+		rconfig.DefaultFilesConfig.SourceUploadPath = s3Output
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))
@@ -138,9 +139,9 @@ func TestRegisterFromFiles(t *testing.T) {
 		registerFilesSetup()
 		testScope := promutils.NewTestScope()
 		labeled.SetMetricKeys(contextutils.AppNameKey, contextutils.ProjectKey, contextutils.DomainKey)
-		defaultFilesConfig.Archive = false
-		defaultFilesConfig.OutputLocationPrefix = s3Output
-		defaultFilesConfig.SourceUploadPath = ""
+		rconfig.DefaultFilesConfig.Archive = false
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = s3Output
+		rconfig.DefaultFilesConfig.SourceUploadPath = ""
 		s, err := storage.NewDataStore(&storage.Config{
 			Type: storage.TypeMemory,
 		}, testScope.NewSubScope("flytectl"))

--- a/cmd/register/register.go
+++ b/cmd/register/register.go
@@ -1,7 +1,6 @@
 package register
 
 import (
-	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdcore "github.com/flyteorg/flytectl/cmd/core"
 
 	"github.com/spf13/cobra"
@@ -26,9 +25,9 @@ func RemoteRegisterCommand() *cobra.Command {
 		Long:  registercmdLong,
 	}
 	registerResourcesFuncs := map[string]cmdcore.CommandEntry{
-		"files": {CmdFunc: registerFromFilesFunc, Aliases: []string{"file"}, PFlagProvider: rconfig.DefaultFilesConfig,
+		"files": {CmdFunc: registerFromFilesFunc, Aliases: []string{"file"}, PFlagProvider: defaultFilesConfig,
 			Short: registerFilesShort, Long: registerFilesLong},
-		"examples": {CmdFunc: registerExamplesFunc, Aliases: []string{"example", "flytesnack", "flytesnacks"}, PFlagProvider: rconfig.DefaultFilesConfig,
+		"examples": {CmdFunc: registerExamplesFunc, Aliases: []string{"example", "flytesnack", "flytesnacks"}, PFlagProvider: defaultFilesConfig,
 			Short: registerExampleShort, Long: registerExampleLong},
 	}
 	cmdcore.AddCommands(registerCmd, registerResourcesFuncs)

--- a/cmd/register/register.go
+++ b/cmd/register/register.go
@@ -1,6 +1,7 @@
 package register
 
 import (
+	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdcore "github.com/flyteorg/flytectl/cmd/core"
 
 	"github.com/spf13/cobra"
@@ -25,9 +26,9 @@ func RemoteRegisterCommand() *cobra.Command {
 		Long:  registercmdLong,
 	}
 	registerResourcesFuncs := map[string]cmdcore.CommandEntry{
-		"files": {CmdFunc: registerFromFilesFunc, Aliases: []string{"file"}, PFlagProvider: defaultFilesConfig,
+		"files": {CmdFunc: registerFromFilesFunc, Aliases: []string{"file"}, PFlagProvider: rconfig.DefaultFilesConfig,
 			Short: registerFilesShort, Long: registerFilesLong},
-		"examples": {CmdFunc: registerExamplesFunc, Aliases: []string{"example", "flytesnack", "flytesnacks"}, PFlagProvider: defaultFilesConfig,
+		"examples": {CmdFunc: registerExamplesFunc, Aliases: []string{"example", "flytesnack", "flytesnacks"}, PFlagProvider: rconfig.DefaultFilesConfig,
 			Short: registerExampleShort, Long: registerExampleLong},
 	}
 	cmdcore.AddCommands(registerCmd, registerResourcesFuncs)

--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-github/github"
 
 	"github.com/flyteorg/flytectl/cmd/config"
+	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/printer"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -96,11 +97,11 @@ func unMarshalContents(ctx context.Context, fileContents []byte, fname string) (
 
 }
 
-func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.CommandContext) error {
+func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.CommandContext, dryRun bool, version string) error {
 	switch v := message.(type) {
 	case *admin.LaunchPlan:
 		launchPlan := message.(*admin.LaunchPlan)
-		if defaultFilesConfig.DryRun {
+		if dryRun {
 			logger.Debugf(ctx, "skipping CreateLaunchPlan request (DryRun)")
 			return nil
 		}
@@ -111,14 +112,14 @@ func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.Command
 					Project:      config.GetConfig().Project,
 					Domain:       config.GetConfig().Domain,
 					Name:         launchPlan.Id.Name,
-					Version:      defaultFilesConfig.Version,
+					Version:      version,
 				},
 				Spec: launchPlan.Spec,
 			})
 		return err
 	case *admin.WorkflowSpec:
 		workflowSpec := message.(*admin.WorkflowSpec)
-		if defaultFilesConfig.DryRun {
+		if dryRun {
 			logger.Debugf(ctx, "skipping CreateWorkflow request (DryRun)")
 			return nil
 		}
@@ -129,14 +130,14 @@ func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.Command
 					Project:      config.GetConfig().Project,
 					Domain:       config.GetConfig().Domain,
 					Name:         workflowSpec.Template.Id.Name,
-					Version:      defaultFilesConfig.Version,
+					Version:      version,
 				},
 				Spec: workflowSpec,
 			})
 		return err
 	case *admin.TaskSpec:
 		taskSpec := message.(*admin.TaskSpec)
-		if defaultFilesConfig.DryRun {
+		if dryRun {
 			logger.Debugf(ctx, "skipping CreateTask request (DryRun)")
 			return nil
 		}
@@ -147,7 +148,7 @@ func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.Command
 					Project:      config.GetConfig().Project,
 					Domain:       config.GetConfig().Domain,
 					Name:         taskSpec.Template.Id.Name,
-					Version:      defaultFilesConfig.Version,
+					Version:      version,
 				},
 				Spec: taskSpec,
 			})
@@ -157,33 +158,33 @@ func register(ctx context.Context, message proto.Message, cmdCtx cmdCore.Command
 	}
 }
 
-func hydrateNode(node *core.Node) error {
+func hydrateNode(node *core.Node, version string) error {
 	targetNode := node.Target
 	switch v := targetNode.(type) {
 	case *core.Node_TaskNode:
 		taskNodeWrapper := targetNode.(*core.Node_TaskNode)
 		taskNodeReference := taskNodeWrapper.TaskNode.Reference.(*core.TaskNode_ReferenceId)
-		hydrateIdentifier(taskNodeReference.ReferenceId)
+		hydrateIdentifier(taskNodeReference.ReferenceId, version)
 	case *core.Node_WorkflowNode:
 		workflowNodeWrapper := targetNode.(*core.Node_WorkflowNode)
 		switch workflowNodeWrapper.WorkflowNode.Reference.(type) {
 		case *core.WorkflowNode_SubWorkflowRef:
 			subWorkflowNodeReference := workflowNodeWrapper.WorkflowNode.Reference.(*core.WorkflowNode_SubWorkflowRef)
-			hydrateIdentifier(subWorkflowNodeReference.SubWorkflowRef)
+			hydrateIdentifier(subWorkflowNodeReference.SubWorkflowRef, version)
 		case *core.WorkflowNode_LaunchplanRef:
 			launchPlanNodeReference := workflowNodeWrapper.WorkflowNode.Reference.(*core.WorkflowNode_LaunchplanRef)
-			hydrateIdentifier(launchPlanNodeReference.LaunchplanRef)
+			hydrateIdentifier(launchPlanNodeReference.LaunchplanRef, version)
 		default:
 			return fmt.Errorf("unknown type %T", workflowNodeWrapper.WorkflowNode.Reference)
 		}
 	case *core.Node_BranchNode:
 		branchNodeWrapper := targetNode.(*core.Node_BranchNode)
-		if err := hydrateNode(branchNodeWrapper.BranchNode.IfElse.Case.ThenNode); err != nil {
+		if err := hydrateNode(branchNodeWrapper.BranchNode.IfElse.Case.ThenNode, version); err != nil {
 			return fmt.Errorf("failed to hydrateNode")
 		}
 		if len(branchNodeWrapper.BranchNode.IfElse.Other) > 0 {
 			for _, ifBlock := range branchNodeWrapper.BranchNode.IfElse.Other {
-				if err := hydrateNode(ifBlock.ThenNode); err != nil {
+				if err := hydrateNode(ifBlock.ThenNode, version); err != nil {
 					return fmt.Errorf("failed to hydrateNode")
 				}
 			}
@@ -191,7 +192,7 @@ func hydrateNode(node *core.Node) error {
 		switch branchNodeWrapper.BranchNode.IfElse.Default.(type) {
 		case *core.IfElseBlock_ElseNode:
 			elseNodeReference := branchNodeWrapper.BranchNode.IfElse.Default.(*core.IfElseBlock_ElseNode)
-			if err := hydrateNode(elseNodeReference.ElseNode); err != nil {
+			if err := hydrateNode(elseNodeReference.ElseNode, version); err != nil {
 				return fmt.Errorf("failed to hydrateNode")
 			}
 
@@ -206,7 +207,7 @@ func hydrateNode(node *core.Node) error {
 	return nil
 }
 
-func hydrateIdentifier(identifier *core.Identifier) {
+func hydrateIdentifier(identifier *core.Identifier, version string) {
 	if identifier.Project == "" || identifier.Project == registrationProjectPattern {
 		identifier.Project = config.GetConfig().Project
 	}
@@ -214,15 +215,15 @@ func hydrateIdentifier(identifier *core.Identifier) {
 		identifier.Domain = config.GetConfig().Domain
 	}
 	if identifier.Version == "" || identifier.Version == registrationVersionPattern {
-		identifier.Version = defaultFilesConfig.Version
+		identifier.Version = version
 	}
 }
 
-func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string) error {
+func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string, sourceUploadPath string, version string) error {
 	if task.Template.GetContainer() != nil {
 		for k := range task.Template.GetContainer().Args {
 			if task.Template.GetContainer().Args[k] == "" || task.Template.GetContainer().Args[k] == registrationRemotePackagePattern {
-				remotePath, err := getRemoteStoragePath(context.Background(), Client, defaultFilesConfig.SourceUploadPath, sourceCode, defaultFilesConfig.Version)
+				remotePath, err := getRemoteStoragePath(context.Background(), Client, sourceUploadPath, sourceCode, version)
 				if err != nil {
 					return err
 				}
@@ -238,7 +239,7 @@ func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string) error {
 		for containerIdx, container := range podSpec.Containers {
 			for argIdx, arg := range container.Args {
 				if arg == registrationRemotePackagePattern {
-					remotePath, err := getRemoteStoragePath(context.Background(), Client, defaultFilesConfig.SourceUploadPath, sourceCode, defaultFilesConfig.Version)
+					remotePath, err := getRemoteStoragePath(context.Background(), Client, sourceUploadPath, sourceCode, version)
 					if err != nil {
 						return err
 					}
@@ -260,50 +261,50 @@ func hydrateTaskSpec(task *admin.TaskSpec, sourceCode string) error {
 	return nil
 }
 
-func hydrateLaunchPlanSpec(lpSpec *admin.LaunchPlanSpec) {
-	assumableIamRole := len(defaultFilesConfig.AssumableIamRole) > 0
-	k8sServiceAcct := len(defaultFilesConfig.K8sServiceAccount) > 0
-	outputLocationPrefix := len(defaultFilesConfig.OutputLocationPrefix) > 0
+func hydrateLaunchPlanSpec(configAssumableIamRole string, configK8sServiceAccount string, configOutputLocationPrefix string, lpSpec *admin.LaunchPlanSpec) {
+	assumableIamRole := len(configAssumableIamRole) > 0
+	k8sServiceAcct := len(configK8sServiceAccount) > 0
+	outputLocationPrefix := len(configOutputLocationPrefix) > 0
 	if assumableIamRole || k8sServiceAcct {
 		lpSpec.AuthRole = &admin.AuthRole{
-			AssumableIamRole:         defaultFilesConfig.AssumableIamRole,
-			KubernetesServiceAccount: defaultFilesConfig.K8sServiceAccount,
+			AssumableIamRole:         configAssumableIamRole,
+			KubernetesServiceAccount: configK8sServiceAccount,
 		}
 	}
 	if outputLocationPrefix {
 		lpSpec.RawOutputDataConfig = &admin.RawOutputDataConfig{
-			OutputLocationPrefix: defaultFilesConfig.OutputLocationPrefix,
+			OutputLocationPrefix: configOutputLocationPrefix,
 		}
 	}
 }
 
-func hydrateSpec(message proto.Message, sourceCode string) error {
+func hydrateSpec(message proto.Message, sourceCode string, config rconfig.FilesConfig) error {
 	switch v := message.(type) {
 	case *admin.LaunchPlan:
 		launchPlan := message.(*admin.LaunchPlan)
-		hydrateIdentifier(launchPlan.Spec.WorkflowId)
-		hydrateLaunchPlanSpec(launchPlan.Spec)
+		hydrateIdentifier(launchPlan.Spec.WorkflowId, config.Version)
+		hydrateLaunchPlanSpec(config.AssumableIamRole, config.K8sServiceAccount, config.OutputLocationPrefix, launchPlan.Spec)
 	case *admin.WorkflowSpec:
 		workflowSpec := message.(*admin.WorkflowSpec)
 		for _, Noderef := range workflowSpec.Template.Nodes {
-			if err := hydrateNode(Noderef); err != nil {
+			if err := hydrateNode(Noderef, config.Version); err != nil {
 				return err
 			}
 		}
-		hydrateIdentifier(workflowSpec.Template.Id)
+		hydrateIdentifier(workflowSpec.Template.Id, config.Version)
 		for _, subWorkflow := range workflowSpec.SubWorkflows {
 			for _, Noderef := range subWorkflow.Nodes {
-				if err := hydrateNode(Noderef); err != nil {
+				if err := hydrateNode(Noderef, config.Version); err != nil {
 					return err
 				}
 			}
-			hydrateIdentifier(subWorkflow.Id)
+			hydrateIdentifier(subWorkflow.Id, config.Version)
 		}
 	case *admin.TaskSpec:
 		taskSpec := message.(*admin.TaskSpec)
-		hydrateIdentifier(taskSpec.Template.Id)
+		hydrateIdentifier(taskSpec.Template.Id, config.Version)
 		// In case of fast serialize input proto also have on additional variable to substitute i.e destination bucket for source code
-		if err := hydrateTaskSpec(taskSpec, sourceCode); err != nil {
+		if err := hydrateTaskSpec(taskSpec, sourceCode, config.SourceUploadPath, config.Version); err != nil {
 			return err
 		}
 
@@ -330,8 +331,8 @@ Get serialize output file list from the args list.
 If the archive flag is on then download the archives to temp directory and extract it. In case of fast register it will also return the compressed source code
 The o/p of this function would be sorted list of the file locations.
 */
-func getSerializeOutputFiles(ctx context.Context, args []string) ([]string, string, error) {
-	if !defaultFilesConfig.Archive {
+func getSerializeOutputFiles(ctx context.Context, args []string, archive bool) ([]string, string, error) {
+	if !archive {
 		/*
 		 * Sorting is required for non-archived case since its possible for the user to pass in a list of unordered
 		 * serialized protobuf files , but flyte expects them to be registered in topologically sorted order that it had
@@ -405,7 +406,7 @@ func readAndCopyArchive(src io.Reader, tempDir string, unarchivedFiles []string)
 	}
 }
 
-func registerFile(ctx context.Context, fileName, sourceCode string, registerResults []Result, cmdCtx cmdCore.CommandContext) ([]Result, error) {
+func registerFile(ctx context.Context, fileName, sourceCode string, registerResults []Result, cmdCtx cmdCore.CommandContext, config rconfig.FilesConfig) ([]Result, error) {
 	var registerResult Result
 	var fileContents []byte
 	var err error
@@ -421,7 +422,7 @@ func registerFile(ctx context.Context, fileName, sourceCode string, registerResu
 		return registerResults, err
 	}
 
-	if err := hydrateSpec(spec, sourceCode); err != nil {
+	if err := hydrateSpec(spec, sourceCode, config); err != nil {
 		registerResult = Result{Name: fileName, Status: "Failed", Info: fmt.Sprintf("Error hydrating spec due to %v", err)}
 		registerResults = append(registerResults, registerResult)
 		return registerResults, err
@@ -429,7 +430,7 @@ func registerFile(ctx context.Context, fileName, sourceCode string, registerResu
 
 	logger.Debugf(ctx, "Hydrated spec : %v", getJSONSpec(spec))
 
-	if err := register(ctx, spec, cmdCtx); err != nil {
+	if err := register(ctx, spec, cmdCtx, config.DryRun, config.Version); err != nil {
 		// If error is AlreadyExists then dont consider this to be an error but just a warning state
 		if grpcError := status.Code(err); grpcError == codes.AlreadyExists {
 			registerResult = Result{Name: fileName, Status: "Success", Info: fmt.Sprintf("%v", grpcError.String())}
@@ -531,21 +532,21 @@ func getRemoteStoragePath(ctx context.Context, s *storage.DataStore, remoteLocat
 	return remotePath, nil
 }
 
-func uploadFastRegisterArtifact(ctx context.Context, file, sourceCodeName, version string) error {
+func uploadFastRegisterArtifact(ctx context.Context, file, sourceCodeName, version string, sourceUploadPath *string) error {
 	dataStore, err := getStorageClient(ctx)
 	if err != nil {
 		return err
 	}
 	var dataRefReaderCloser io.ReadCloser
-	remotePath := storage.DataReference(defaultFilesConfig.SourceUploadPath)
-	if len(defaultFilesConfig.SourceUploadPath) == 0 {
+	remotePath := storage.DataReference(*sourceUploadPath)
+	if len(*sourceUploadPath) == 0 {
 		remotePath, err = dataStore.ConstructReference(ctx, dataStore.GetBaseContainerFQN(ctx), "fast")
 		if err != nil {
 			return err
 		}
 	}
-	defaultFilesConfig.SourceUploadPath = string(remotePath)
-	fullRemotePath, err := getRemoteStoragePath(ctx, dataStore, defaultFilesConfig.SourceUploadPath, sourceCodeName, version)
+	*sourceUploadPath = string(remotePath)
+	fullRemotePath, err := getRemoteStoragePath(ctx, dataStore, *sourceUploadPath, sourceCodeName, version)
 	if err != nil {
 		return err
 	}
@@ -607,10 +608,10 @@ func segregateSourceAndProtos(dataRefs []string) (string, []string, []string) {
 	return sourceCode, validProto, InvalidFiles
 }
 
-func deprecatedCheck(ctx context.Context) {
-	if len(defaultFilesConfig.K8ServiceAccount) > 0 {
+func deprecatedCheck(ctx context.Context, k8sServiceAccount *string, k8ServiceAccount string) {
+	if len(k8ServiceAccount) > 0 {
 		logger.Warning(ctx, "--K8ServiceAccount is deprecated, Please use --K8sServiceAccount")
-		defaultFilesConfig.K8sServiceAccount = defaultFilesConfig.K8ServiceAccount
+		*k8sServiceAccount = k8ServiceAccount
 	}
 }
 

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
-	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	u "github.com/flyteorg/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -56,15 +55,15 @@ func registerFilesSetup() {
 	mockAdminClient = u.MockClient
 	cmdCtx = cmdCore.NewCommandContext(mockAdminClient, u.MockOutStream)
 
-	rconfig.DefaultFilesConfig.AssumableIamRole = ""
-	rconfig.DefaultFilesConfig.K8sServiceAccount = ""
-	rconfig.DefaultFilesConfig.OutputLocationPrefix = ""
+	defaultFilesConfig.AssumableIamRole = ""
+	defaultFilesConfig.K8sServiceAccount = ""
+	defaultFilesConfig.OutputLocationPrefix = ""
 }
 
 func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-parent-folder-register.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 4)
@@ -81,7 +80,7 @@ func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 func TestGetSortedArchivedFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-register.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 4)
@@ -98,7 +97,7 @@ func TestGetSortedArchivedFileList(t *testing.T) {
 func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-unordered-register.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 4)
@@ -115,7 +114,7 @@ func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 0)
@@ -128,7 +127,7 @@ func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 func TestGetSortedArchivedTgzList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-register.tgz"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 4)
@@ -144,7 +143,7 @@ func TestGetSortedArchivedTgzList(t *testing.T) {
 
 func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 	setup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid.tgz"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, 0, len(fileList))
@@ -157,7 +156,7 @@ func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid-extension-register.zip"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, 0, len(fileList))
@@ -170,7 +169,7 @@ func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 
 func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 	setup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"http://invalidhost:invalidport/testdata/valid-register.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, 0, len(fileList))
@@ -183,7 +182,7 @@ func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"http://dummyhost:80/testdata/valid-register.tar"}
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
 	assert.Equal(t, len(fileList), 4)
@@ -200,7 +199,7 @@ func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 func TestGetSortedArchivedFileThroughValidHttpWithNullContextList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	rconfig.DefaultFilesConfig.Archive = true
+	defaultFilesConfig.Archive = true
 	args = []string{"http://dummyhost:80/testdata/valid-register.tar"}
 	ctx = nil
 	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
@@ -277,7 +276,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("IamRole override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
+		defaultFilesConfig.AssumableIamRole = "iamRole"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole"}, lpSpec.AuthRole)
@@ -285,7 +284,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("k8sService account override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
+		defaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
@@ -293,8 +292,8 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("Both k8sService and IamRole", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
-		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
+		defaultFilesConfig.AssumableIamRole = "iamRole"
+		defaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole",
@@ -303,7 +302,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("Output prefix", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		rconfig.DefaultFilesConfig.OutputLocationPrefix = "prefix"
+		defaultFilesConfig.OutputLocationPrefix = "prefix"
 		lpSpec := &admin.LaunchPlanSpec{}
 		hydrateLaunchPlanSpec(lpSpec)
 		assert.Equal(t, &admin.RawOutputDataConfig{OutputLocationPrefix: "prefix"}, lpSpec.RawOutputDataConfig)

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
+	rconfig "github.com/flyteorg/flytectl/cmd/config/subcommand/register"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	u "github.com/flyteorg/flytectl/cmd/testutils"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -55,17 +56,17 @@ func registerFilesSetup() {
 	mockAdminClient = u.MockClient
 	cmdCtx = cmdCore.NewCommandContext(mockAdminClient, u.MockOutStream)
 
-	defaultFilesConfig.AssumableIamRole = ""
-	defaultFilesConfig.K8sServiceAccount = ""
-	defaultFilesConfig.OutputLocationPrefix = ""
+	rconfig.DefaultFilesConfig.AssumableIamRole = ""
+	rconfig.DefaultFilesConfig.K8sServiceAccount = ""
+	rconfig.DefaultFilesConfig.OutputLocationPrefix = ""
 }
 
 func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-parent-folder-register.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 4)
 	assert.Equal(t, filepath.Join(tmpDir, "parentfolder", "014_recipes.core.basic.basic_workflow.t1_1.pb"), fileList[0])
 	assert.Equal(t, filepath.Join(tmpDir, "parentfolder", "015_recipes.core.basic.basic_workflow.t2_1.pb"), fileList[1])
@@ -80,9 +81,9 @@ func TestGetSortedArchivedFileWithParentFolderList(t *testing.T) {
 func TestGetSortedArchivedFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-register.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 4)
 	assert.Equal(t, filepath.Join(tmpDir, "014_recipes.core.basic.basic_workflow.t1_1.pb"), fileList[0])
 	assert.Equal(t, filepath.Join(tmpDir, "015_recipes.core.basic.basic_workflow.t2_1.pb"), fileList[1])
@@ -97,9 +98,9 @@ func TestGetSortedArchivedFileList(t *testing.T) {
 func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-unordered-register.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 4)
 	assert.Equal(t, filepath.Join(tmpDir, "014_recipes.core.basic.basic_workflow.t1_1.pb"), fileList[0])
 	assert.Equal(t, filepath.Join(tmpDir, "015_recipes.core.basic.basic_workflow.t2_1.pb"), fileList[1])
@@ -114,9 +115,9 @@ func TestGetSortedArchivedFileUnorderedList(t *testing.T) {
 func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 0)
 	assert.True(t, strings.HasPrefix(tmpDir, "/tmp/register"))
 	assert.NotNil(t, err)
@@ -127,9 +128,9 @@ func TestGetSortedArchivedCorruptedFileList(t *testing.T) {
 func TestGetSortedArchivedTgzList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/valid-register.tgz"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 4)
 	assert.Equal(t, filepath.Join(tmpDir, "014_recipes.core.basic.basic_workflow.t1_1.pb"), fileList[0])
 	assert.Equal(t, filepath.Join(tmpDir, "015_recipes.core.basic.basic_workflow.t2_1.pb"), fileList[1])
@@ -143,9 +144,9 @@ func TestGetSortedArchivedTgzList(t *testing.T) {
 
 func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 	setup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid.tgz"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, 0, len(fileList))
 	assert.True(t, strings.HasPrefix(tmpDir, "/tmp/register"))
 	assert.NotNil(t, err)
@@ -156,9 +157,9 @@ func TestGetSortedArchivedCorruptedTgzFileList(t *testing.T) {
 func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"testdata/invalid-extension-register.zip"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, 0, len(fileList))
 	assert.True(t, strings.HasPrefix(tmpDir, "/tmp/register"))
 	assert.NotNil(t, err)
@@ -169,9 +170,9 @@ func TestGetSortedArchivedInvalidArchiveFileList(t *testing.T) {
 
 func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 	setup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"http://invalidhost:invalidport/testdata/valid-register.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, 0, len(fileList))
 	assert.True(t, strings.HasPrefix(tmpDir, "/tmp/register"))
 	assert.NotNil(t, err)
@@ -182,9 +183,9 @@ func TestGetSortedArchivedFileThroughInvalidHttpList(t *testing.T) {
 func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"http://dummyhost:80/testdata/valid-register.tar"}
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 4)
 	assert.Equal(t, filepath.Join(tmpDir, "014_recipes.core.basic.basic_workflow.t1_1.pb"), fileList[0])
 	assert.Equal(t, filepath.Join(tmpDir, "015_recipes.core.basic.basic_workflow.t2_1.pb"), fileList[1])
@@ -199,10 +200,10 @@ func TestGetSortedArchivedFileThroughValidHttpList(t *testing.T) {
 func TestGetSortedArchivedFileThroughValidHttpWithNullContextList(t *testing.T) {
 	setup()
 	registerFilesSetup()
-	defaultFilesConfig.Archive = true
+	rconfig.DefaultFilesConfig.Archive = true
 	args = []string{"http://dummyhost:80/testdata/valid-register.tar"}
 	ctx = nil
-	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args)
+	fileList, tmpDir, err := getSerializeOutputFiles(ctx, args, rconfig.DefaultFilesConfig.Archive)
 	assert.Equal(t, len(fileList), 0)
 	assert.True(t, strings.HasPrefix(tmpDir, "/tmp/register"))
 	assert.NotNil(t, err)
@@ -218,7 +219,7 @@ func TestRegisterFile(t *testing.T) {
 		mockAdminClient.OnCreateTaskMatch(mock.Anything, mock.Anything).Return(nil, nil)
 		args = []string{"testdata/69_core.flyte_basics.lp.greet_1.pb"}
 		var registerResults []Result
-		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx)
+		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx, *rconfig.DefaultFilesConfig)
 		assert.Equal(t, 1, len(results))
 		assert.Nil(t, err)
 	})
@@ -227,7 +228,7 @@ func TestRegisterFile(t *testing.T) {
 		registerFilesSetup()
 		args = []string{"testdata/non-existent.pb"}
 		var registerResults []Result
-		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx)
+		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx, *rconfig.DefaultFilesConfig)
 		assert.Equal(t, 1, len(results))
 		assert.Equal(t, "Failed", results[0].Status)
 		assert.Equal(t, "Error reading file due to open testdata/non-existent.pb: no such file or directory", results[0].Info)
@@ -238,7 +239,7 @@ func TestRegisterFile(t *testing.T) {
 		registerFilesSetup()
 		args = []string{"testdata/valid-register.tar"}
 		var registerResults []Result
-		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx)
+		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx, *rconfig.DefaultFilesConfig)
 		assert.Equal(t, 1, len(results))
 		assert.Equal(t, "Failed", results[0].Status)
 		assert.Equal(t, "Error unmarshalling file due to failed unmarshalling file testdata/valid-register.tar", results[0].Info)
@@ -251,7 +252,7 @@ func TestRegisterFile(t *testing.T) {
 			status.Error(codes.AlreadyExists, "AlreadyExists"))
 		args = []string{"testdata/69_core.flyte_basics.lp.greet_1.pb"}
 		var registerResults []Result
-		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx)
+		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx, *rconfig.DefaultFilesConfig)
 		assert.Equal(t, 1, len(results))
 		assert.Equal(t, "Success", results[0].Status)
 		assert.Equal(t, "AlreadyExists", results[0].Info)
@@ -264,7 +265,7 @@ func TestRegisterFile(t *testing.T) {
 			status.Error(codes.InvalidArgument, "Invalid"))
 		args = []string{"testdata/69_core.flyte_basics.lp.greet_1.pb"}
 		var registerResults []Result
-		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx)
+		results, err := registerFile(ctx, args[0], "", registerResults, cmdCtx, *rconfig.DefaultFilesConfig)
 		assert.Equal(t, 1, len(results))
 		assert.Equal(t, "Failed", results[0].Status)
 		assert.Equal(t, "Error registering file due to rpc error: code = InvalidArgument desc = Invalid", results[0].Info)
@@ -276,35 +277,35 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 	t.Run("IamRole override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		defaultFilesConfig.AssumableIamRole = "iamRole"
+		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
 		lpSpec := &admin.LaunchPlanSpec{}
-		hydrateLaunchPlanSpec(lpSpec)
+		hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole"}, lpSpec.AuthRole)
 	})
 	t.Run("k8sService account override", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		defaultFilesConfig.K8sServiceAccount = "k8Account"
+		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
-		hydrateLaunchPlanSpec(lpSpec)
+		hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Equal(t, &admin.AuthRole{KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
 	})
 	t.Run("Both k8sService and IamRole", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		defaultFilesConfig.AssumableIamRole = "iamRole"
-		defaultFilesConfig.K8sServiceAccount = "k8Account"
+		rconfig.DefaultFilesConfig.AssumableIamRole = "iamRole"
+		rconfig.DefaultFilesConfig.K8sServiceAccount = "k8Account"
 		lpSpec := &admin.LaunchPlanSpec{}
-		hydrateLaunchPlanSpec(lpSpec)
+		hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole",
 			KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
 	})
 	t.Run("Output prefix", func(t *testing.T) {
 		setup()
 		registerFilesSetup()
-		defaultFilesConfig.OutputLocationPrefix = "prefix"
+		rconfig.DefaultFilesConfig.OutputLocationPrefix = "prefix"
 		lpSpec := &admin.LaunchPlanSpec{}
-		hydrateLaunchPlanSpec(lpSpec)
+		hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Equal(t, &admin.RawOutputDataConfig{OutputLocationPrefix: "prefix"}, lpSpec.RawOutputDataConfig)
 	})
 }
@@ -318,7 +319,7 @@ func TestUploadFastRegisterArtifact(t *testing.T) {
 		}, testScope.NewSubScope("flytectl"))
 		assert.Nil(t, err)
 		Client = s
-		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacks-core.tgz", "flytesnacks-core.tgz", "")
+		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacks-core.tgz", "flytesnacks-core.tgz", "", &rconfig.DefaultFilesConfig.SourceUploadPath)
 		assert.Nil(t, err)
 	})
 	t.Run("Failed upload", func(t *testing.T) {
@@ -329,7 +330,7 @@ func TestUploadFastRegisterArtifact(t *testing.T) {
 		}, testScope.NewSubScope("flytectl"))
 		assert.Nil(t, err)
 		Client = s
-		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacks-core.tgz", "", "")
+		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacks-core.tgz", "", "", &rconfig.DefaultFilesConfig.SourceUploadPath)
 		assert.Nil(t, err)
 	})
 	t.Run("Failed upload", func(t *testing.T) {
@@ -340,7 +341,7 @@ func TestUploadFastRegisterArtifact(t *testing.T) {
 		}, testScope.NewSubScope("flytectl"))
 		assert.Nil(t, err)
 		Client = s
-		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacksre.tgz", "", "")
+		err = uploadFastRegisterArtifact(ctx, "testdata/flytesnacksre.tgz", "", "", &rconfig.DefaultFilesConfig.SourceUploadPath)
 		assert.NotNil(t, err)
 	})
 }
@@ -378,7 +379,7 @@ func TestRegister(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		node := &admin.NodeExecution{}
-		err := register(ctx, node, cmdCtx)
+		err := register(ctx, node, cmdCtx, rconfig.DefaultFilesConfig.DryRun, rconfig.DefaultFilesConfig.Version)
 		assert.NotNil(t, err)
 	})
 }
@@ -388,7 +389,7 @@ func TestHydrateNode(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		node := &core.Node{}
-		err := hydrateNode(node)
+		err := hydrateNode(node, rconfig.DefaultFilesConfig.Version)
 		assert.NotNil(t, err)
 	})
 
@@ -396,7 +397,7 @@ func TestHydrateNode(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		task := &admin.Task{}
-		err := hydrateSpec(task, "")
+		err := hydrateSpec(task, "", *rconfig.DefaultFilesConfig)
 		assert.NotNil(t, err)
 	})
 }
@@ -444,7 +445,7 @@ func TestHydrateTaskSpec(t *testing.T) {
 			},
 		},
 	}
-	err = hydrateTaskSpec(task, "sourcey")
+	err = hydrateTaskSpec(task, "sourcey", rconfig.DefaultFilesConfig.SourceUploadPath, rconfig.DefaultFilesConfig.Version)
 	assert.NoError(t, err)
 	var hydratedPodSpec = v1.PodSpec{}
 	err = utils.UnmarshalStructToObj(task.Template.GetK8SPod().PodSpec, &hydratedPodSpec)


### PR DESCRIPTION
# TL;DR
Flytectl code has one issue. Internal method/pkg use flags directly rather than using them as parameters. We should only use flags in the root command. After that, we should pass the value in the method.

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Just refactor.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1617

## Follow-up issue
_NA_
