### PR TITLE
Correctly demultiplex sandbox Docker exec output #patch

### DIFF
--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/enescakir/emoji"
 	cmdUtil "github.com/flyteorg/flytectl/pkg/commandutils"
@@ -174,9 +175,9 @@ func InspectExecResp(ctx context.Context, cli Docker, containerID string) error 
 	if err != nil {
 		return err
 	}
-	s := bufio.NewScanner(resp.Reader)
-	for s.Scan() {
-		fmt.Println(s.Text())
+	_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, resp.Reader)
+	if err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
# TL;DR
This PR fixes output problems in `flytectl sandbox exec` due to incorrect demultiplexing of output streams returned by Docker client.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
When running commands inside the sandbox container, the output is garbled and contains non-printable characters (`\0`, `\1`, among others). See below for a reproducing example of a Docker image build inside the sandbox (note the first column contains random characters for some lines).

After some digging, I was able to narrow the problem down to the way that the Docker client handles outputs from the container stdout and stderr streams by multiplexing them into a single `Reader`. This behavior is documented for the `ContainerAttach` method (https://pkg.go.dev/github.com/docker/docker/client#Client.ContainerAttach), which suggests the use of `stdcopy.StdCopy()` to correctly handle such multiplexed streams. Strangely enough, this hint is missing for `ContainerAttachExec`, which is what the current implementation in flytectl is using.

Replacing the manual printing of container outputs with `stdcopy.StdCopy()` solves the issues with garbled output and also seems to improve the latency of the output (probably due to not scanning entire lines in the log output).

<details><summary>Output of latest upstream flytectl</summary>
<pre>
$ flytectl sandbox exec -- docker build . --tag "demo_app:v1"
INFO[0000] [0] Couldn't find a config file []. Relying on env vars and pflags.
{"json":{},"level":"error","msg":"failed to initialize token source provider. Err: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"","ts":"2021-11-10T10:12:30+01:00"}
{"json":{},"level":"warning","msg":"Starting an unauthenticated client because: can't create authenticated channel without a TokenSourceProvider","ts":"2021-11-10T10:12:30+01:00"}
{"json":{},"level":"info","msg":"Initialized Admin client","ts":"2021-11-10T10:12:30+01:00"}
3Sending build context to Docker daemon  45.37MB
+Step 1/14 : FROM python:3.9-slim-bullseye
/ ---> 5e714d33137a
Step 2/14 : WORKDIR /root
G ---> Using cache
 ---> 6b02d67f0daa
Step 3/14 : ENV VENV /opt/venv
E ---> Using cache
 ---> 78c4ac629a15
Step 4/14 : ENV LANG C.UTF-8
G ---> Using cache
 ---> 7f0d66d126d0
Step 5/14 : ENV LC_ALL C.UTF-8
I ---> Using cache
 ---> 1e3bd5d00298
Step 6/14 : ENV PYTHONPATH /root
 ---> Using cache
 ---> 01b0386e6387
Step 7/14 : RUN apt-get update -yqq &&     apt-get install -yqq build-essential curl &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
' ---> Using cache
 ---> b38c7961882c
Step 8/14 : RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | POETRY_HOME=/opt/poetry python &&     cd /usr/local/bin &&     ln -s /opt/poetry/bin/poetry &&     poetry config virtualenvs.create false
B ---> Using cache
 ---> 554bf8d8f161
Step 9/14 : WORKDIR /root
a ---> Using cache
 ---> 70097996ce8e
Step 10/14 : COPY ./pyproject.toml ./poetry.lock* /root/
z ---> Using cache
 ---> 3795cab2c4ad
Step 11/14 : RUN poetry install --no-root --no-dev &&     rm -r ~/.cache/pypoetry
B ---> Using cache
 ---> 23846b2721f6
Step 12/14 : COPY . /root
= ---> Using cache
 ---> 0899722bcbac
Step 13/14 : ARG tag
S ---> Using cache
 ---> 4cc36884e300
Step 14/14 : ENV FLYTE_INTERNAL_IMAGE $tag
' ---> Using cache
 ---> 1881cfe6667f
!Successfully built 1881cfe6667f
!Successfully tagged demo_app:v1
</pre>
</details>

<details><summary>Output of proposed patch</summary>
<pre>
$ ~/software/flytectl/bin/flytectl sandbox exec -- docker build . --tag "demo_app:v1"
INFO[0000] [0] Couldn't find a config file []. Relying on env vars and pflags.
{"json":{},"level":"error","msg":"failed to initialize token source provider. Err: failed to fetch auth metadata. Error: rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial tcp: missing address\"","ts":"2021-11-10T10:12:59+01:00"}
{"json":{},"level":"warning","msg":"Starting an unauthenticated client because: can't create authenticated channel without a TokenSourceProvider","ts":"2021-11-10T10:12:59+01:00"}
{"json":{},"level":"info","msg":"Initialized Admin client","ts":"2021-11-10T10:12:59+01:00"}
Sending build context to Docker daemon  45.37MB
Step 1/14 : FROM python:3.9-slim-bullseye
 ---> 5e714d33137a
Step 2/14 : WORKDIR /root
 ---> Using cache
 ---> 6b02d67f0daa
Step 3/14 : ENV VENV /opt/venv
 ---> Using cache
 ---> 78c4ac629a15
Step 4/14 : ENV LANG C.UTF-8
 ---> Using cache
 ---> 7f0d66d126d0
Step 5/14 : ENV LC_ALL C.UTF-8
 ---> Using cache
 ---> 1e3bd5d00298
Step 6/14 : ENV PYTHONPATH /root
 ---> Using cache
 ---> 01b0386e6387
Step 7/14 : RUN apt-get update -yqq &&     apt-get install -yqq build-essential curl &&     apt-get clean &&     rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> b38c7961882c
Step 8/14 : RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | POETRY_HOME=/opt/poetry python &&     cd /usr/local/bin &&     ln -s /opt/poetry/bin/poetry &&     poetry config virtualenvs.create false
 ---> Using cache
 ---> 554bf8d8f161
Step 9/14 : WORKDIR /root
 ---> Using cache
 ---> 70097996ce8e
Step 10/14 : COPY ./pyproject.toml ./poetry.lock* /root/
 ---> Using cache
 ---> 3795cab2c4ad
Step 11/14 : RUN poetry install --no-root --no-dev &&     rm -r ~/.cache/pypoetry
 ---> Using cache
 ---> 23846b2721f6
Step 12/14 : COPY . /root
 ---> Using cache
 ---> 0899722bcbac
Step 13/14 : ARG tag
 ---> Using cache
 ---> 4cc36884e300
Step 14/14 : ENV FLYTE_INTERNAL_IMAGE $tag
 ---> Using cache
 ---> 1881cfe6667f
Successfully built 1881cfe6667f
Successfully tagged demo_app:v1
</pre>
</details>

## Tracking Issue

Haven't created one yet, but can add one for completeness. Should I?

## Follow-up issue
_NA_
