### PR TITLE
Improve flytectl config init UX 

### DIFF
--- a/cmd/config/subcommand/config/init_flags.go
+++ b/cmd/config/subcommand/config/init_flags.go
@@ -3,7 +3,7 @@ package config
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
 	DefaultConfig = &Config{
-		Insecure: true,
+		Insecure: false,
 		Storage:  false,
 	}
 )

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -51,6 +51,8 @@ var prompt = promptui.Select{
 	Items: []string{"S3", "GCS"},
 }
 
+var dnsPrefix = [3]string{"dns://", "http://", "https://"}
+
 // CreateConfigCommand will return configuration command
 func CreateConfigCommand() *cobra.Command {
 	configCmd := viper.GetConfigCommand()
@@ -82,7 +84,7 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 	templateStr := configutil.GetSandboxTemplate()
 
 	if len(initConfig.DefaultConfig.Host) > 0 {
-		templateValues.Host = fmt.Sprintf("dns:///%v", initConfig.DefaultConfig.Host)
+		templateValues.Host = fmt.Sprintf("dns://%s", trim(initConfig.DefaultConfig.Host))
 		templateStr = configutil.AdminConfigTemplate
 		if initConfig.DefaultConfig.Storage {
 			templateStr = configutil.GetAWSCloudTemplate()
@@ -113,4 +115,12 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 	}
 	fmt.Printf("Init flytectl config file at [%s]", configutil.ConfigFile)
 	return nil
+}
+
+func trim(hostname string) string {
+	for _, prefix := range dnsPrefix {
+		hostname = strings.Trim(hostname, prefix)
+	}
+	return hostname
+
 }

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -31,18 +31,24 @@ Generates sandbox config. Flyte Sandbox is a fully standalone minimal environmen
 
 ::
 
- flytectl configuration config 
+ flytectl config init  
 
-Generates remote cluster config. Read more about the remote deployment https://docs.flyte.org/en/latest/deployment/index.html
+Generates remote cluster config, By default connection is secure. Read more about the remote deployment https://docs.flyte.org/en/latest/deployment/index.html
 	
 ::
 
- flytectl configuration config --host=flyte.myexample.com
-	
+ flytectl config init --host=flyte.myexample.com
+
+Generates remote cluster config with insecure connection
+
+::
+
+ flytectl config init --host=flyte.myexample.com --insecure 
+
 Generates FlyteCTL config with a storage provider
 ::
 
- flytectl configuration config --host=flyte.myexample.com --storage
+ flytectl config init --host=flyte.myexample.com --storage
 `
 )
 
@@ -51,7 +57,7 @@ var prompt = promptui.Select{
 	Items: []string{"S3", "GCS"},
 }
 
-var dnsPrefix = [3]string{"dns://", "http://", "https://"}
+var endpointPrefix = [3]string{"dns://", "http://", "https://"}
 
 // CreateConfigCommand will return configuration command
 func CreateConfigCommand() *cobra.Command {
@@ -119,8 +125,8 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 }
 
 func trim(hostname string) string {
-	for _, prefix := range dnsPrefix {
-		hostname = strings.Trim(hostname, prefix)
+	for _, prefix := range endpointPrefix {
+		hostname = strings.TrimPrefix(hostname, prefix)
 	}
 	return hostname
 

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -79,12 +79,13 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 
 	templateValues := configutil.ConfigTemplateSpec{
 		Host:     "dns:///localhost:30081",
-		Insecure: initConfig.DefaultConfig.Insecure,
+		Insecure: true,
 	}
 	templateStr := configutil.GetSandboxTemplate()
 
 	if len(initConfig.DefaultConfig.Host) > 0 {
 		templateValues.Host = fmt.Sprintf("dns://%s", trim(initConfig.DefaultConfig.Host))
+		templateValues.Insecure = initConfig.DefaultConfig.Insecure
 		templateStr = configutil.AdminConfigTemplate
 		if initConfig.DefaultConfig.Storage {
 			templateStr = configutil.GetAWSCloudTemplate()

--- a/cmd/configuration/configuration_test.go
+++ b/cmd/configuration/configuration_test.go
@@ -56,7 +56,7 @@ func TestSetupConfigFunc(t *testing.T) {
 	assert.Nil(t, initFlytectlConfig(ctx, yes))
 	assert.Nil(t, initFlytectlConfig(ctx, yes))
 	assert.Nil(t, initFlytectlConfig(ctx, no))
-	initConfig.DefaultConfig.Host = "test"
+	initConfig.DefaultConfig.Host = "flyte.org"
 	assert.Nil(t, initFlytectlConfig(ctx, no))
 	initConfig.DefaultConfig.Storage = true
 	assert.NotNil(t, initFlytectlConfig(ctx, yes))
@@ -66,4 +66,12 @@ func TestTrimFunc(t *testing.T) {
 	assert.Equal(t, trim("dns://localhost"), "localhost")
 	assert.Equal(t, trim("http://localhost"), "localhost")
 	assert.Equal(t, trim("https://localhost"), "localhost")
+}
+
+func TestValidateEndpointName(t *testing.T) {
+	assert.Equal(t, validateEndpointName("127.0.0.1"), true)
+	assert.Equal(t, validateEndpointName("127.0.0.1.0"), false)
+	assert.Equal(t, validateEndpointName("localhost"), true)
+	assert.Equal(t, validateEndpointName("flyte.org"), true)
+	assert.Equal(t, validateEndpointName("flyte"), false)
 }

--- a/cmd/configuration/configuration_test.go
+++ b/cmd/configuration/configuration_test.go
@@ -61,3 +61,9 @@ func TestSetupConfigFunc(t *testing.T) {
 	initConfig.DefaultConfig.Storage = true
 	assert.NotNil(t, initFlytectlConfig(ctx, yes))
 }
+
+func TestTrimFunc(t *testing.T) {
+	assert.Equal(t, trim("dns://localhost"), "localhost")
+	assert.Equal(t, trim("http://localhost"), "localhost")
+	assert.Equal(t, trim("https://localhost"), "localhost")
+}

--- a/cmd/configuration/configuration_test.go
+++ b/cmd/configuration/configuration_test.go
@@ -58,6 +58,8 @@ func TestSetupConfigFunc(t *testing.T) {
 	assert.Nil(t, initFlytectlConfig(ctx, no))
 	initConfig.DefaultConfig.Host = "flyte.org"
 	assert.Nil(t, initFlytectlConfig(ctx, no))
+	initConfig.DefaultConfig.Host = "localhost:30081"
+	assert.Nil(t, initFlytectlConfig(ctx, no))
 	initConfig.DefaultConfig.Storage = true
 	assert.NotNil(t, initFlytectlConfig(ctx, yes))
 }


### PR DESCRIPTION
# TL;DR
- In `config init`, Added logic for timing host name (Now host will trim `dns://`, `https://` & `http://` )
- Now in `config init` default value of insecure would be false

Testing 
- flytectl config init --host=google (Will fail)
- flytectl config init  --host=127.0.0.1 (will pass)
- flytectl config init  --host=localhost (will pass)
- flytectl config init  --host=127.0.0.1.0 (will fail)

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1880

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
