### PR TITLE
Update sandbox default config in the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,7 @@
 .. flytectl doc
 
 ######################
-``Flytectl`` Reference
+Flytectl Reference
 ######################
 
 Overview
@@ -59,7 +59,7 @@ Flytectl configuration
         admin:
           # For GRPC endpoints you might want to use dns:///flyte.myexample.com
           endpoint: dns:///localhost:30081
-          insecure: false # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
+          insecure: true # Set to false to enable TLS/SSL connection (not recommended except on local sandbox deployment)
           authType: Pkce # authType: Pkce # if using authentication or just drop this.
         storage:
           connection:


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
From https://github.com/flyteorg/flyte/issues/1701#issuecomment-946213540
> https://docs.flyte.org/projects/flytectl/en/stable/index.html the config for flytesandbox indicates enable auth, which is not really required.

Update insecure to true which is the default value when we start the sandbox

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1701

## Follow-up issue
_NA_