### PR TITLE
Fixed the version bug and also added force flag

### DIFF
--- a/cmd/config/subcommand/register/files_config.go
+++ b/cmd/config/subcommand/register/files_config.go
@@ -11,7 +11,8 @@ var (
 
 // FilesConfig containing flags used for registration
 type FilesConfig struct {
-	Version              string `json:"version" pflag:",version of the entity to be registered with flyte."`
+	Version              string `json:"version" pflag:",version of the entity to be registered with flyte which are un-versioned after serialization."`
+	Force                bool   `json:"force" pflag:",force use of version number on entities registered with flyte."`
 	ContinueOnError      bool   `json:"continueOnError" pflag:",continue on error when registering files."`
 	Archive              bool   `json:"archive" pflag:",pass in archive file either an http link or local path."`
 	AssumableIamRole     string `json:"assumableIamRole" pflag:", custom assumable iam auth role to register launch plans with."`

--- a/cmd/config/subcommand/register/filesconfig_flags.go
+++ b/cmd/config/subcommand/register/filesconfig_flags.go
@@ -50,7 +50,8 @@ func (FilesConfig) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg FilesConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("FilesConfig", pflag.ExitOnError)
-	cmdFlags.StringVar(&DefaultFilesConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultFilesConfig.Version, "version of the entity to be registered with flyte.")
+	cmdFlags.StringVar(&DefaultFilesConfig.Version, fmt.Sprintf("%v%v", prefix, "version"), DefaultFilesConfig.Version, "version of the entity to be registered with flyte which are un-versioned after serialization.")
+	cmdFlags.BoolVar(&DefaultFilesConfig.Force, fmt.Sprintf("%v%v", prefix, "force"), DefaultFilesConfig.Force, "force use of version number on entities registered with flyte.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.ContinueOnError, fmt.Sprintf("%v%v", prefix, "continueOnError"), DefaultFilesConfig.ContinueOnError, "continue on error when registering files.")
 	cmdFlags.BoolVar(&DefaultFilesConfig.Archive, fmt.Sprintf("%v%v", prefix, "archive"), DefaultFilesConfig.Archive, "pass in archive file either an http link or local path.")
 	cmdFlags.StringVar(&DefaultFilesConfig.AssumableIamRole, fmt.Sprintf("%v%v", prefix, "assumableIamRole"), DefaultFilesConfig.AssumableIamRole, " custom assumable iam auth role to register launch plans with.")

--- a/cmd/config/subcommand/register/filesconfig_flags_test.go
+++ b/cmd/config/subcommand/register/filesconfig_flags_test.go
@@ -113,6 +113,20 @@ func TestFilesConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_force", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("force", testValue)
+			if vBool, err := cmdFlags.GetBool("force"); err == nil {
+				testDecodeJson_FilesConfig(t, fmt.Sprintf("%v", vBool), &actual.Force)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_continueOnError", func(t *testing.T) {
 
 		t.Run("Override", func(t *testing.T) {

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -478,7 +478,7 @@ func TestRegister(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		node := &admin.NodeExecution{}
-		err := register(ctx, node, cmdCtx, rconfig.DefaultFilesConfig.DryRun, rconfig.DefaultFilesConfig.Version)
+		err := register(ctx, node, cmdCtx, rconfig.DefaultFilesConfig.DryRun)
 		assert.NotNil(t, err)
 	})
 }
@@ -488,7 +488,7 @@ func TestHydrateNode(t *testing.T) {
 		setup()
 		registerFilesSetup()
 		node := &core.Node{}
-		err := hydrateNode(node, rconfig.DefaultFilesConfig.Version)
+		err := hydrateNode(node, rconfig.DefaultFilesConfig.Version, true)
 		assert.NotNil(t, err)
 	})
 


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Fixes the version substitution bug

If serialization has generated version identifier to be used for various flyte entities then those should be used instead of passed in version flag.

An additional force flag has been introduced which overrides the above behavior and uses the passed in version for all registerable flyte entities irrespective of there serialization status

Testing done  : 

####  Passed version flag but no force flag . Entities would be registered with serialized version
```
flytectl register file  /Users/praful/Downloads/out.tar.gz  -d development  -p chariot-sdk-test  --version v1 --logger.level 2 --archive 
 ---------------------------------------------------------------------- --------- ------------------------------ 
| NAME (4)                                                             | STATUS  | ADDITIONAL INFO              |
 ---------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register407864907/0_pm.nb.new.ipynb_1.pb                        | Success | Successfully registered file |
 ---------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register407864907/1_new.ipynb_1.pb                              | Success | Successfully registered file |
 ---------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register407864907/2_workflows.new_workflow.nb_to_python_wf_2.pb | Success | Successfully registered file |
 ---------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register407864907/3_workflows.new_workflow.nb_to_python_wf_3.pb | Success | Successfully registered file |
 ---------------------------------------------------------------------- --------- ------------------------------ 
```

#### Flyte entities registered with serialized version 1

```
flytectl get task -p chariot-sdk-test -d development --logger.level 6

 --------- ----------------- ---------------- -------- ----------------- -------------- ------------------- ----------------------------- 
| VERSION | NAME            | TYPE           | INPUTS | OUTPUTS         | DISCOVERABLE | DISCOVERY VERSION | CREATED AT                  |
 --------- ----------------- ---------------- -------- ----------------- -------------- ------------------- ----------------------------- 
| 1       | new.ipynb       | nb-python-task | a      | message         |              |                   | 2021-12-22T12:00:05.633777Z |
|         |                 |                | b      | out_nb          |              |                   |                             |
|         |                 |                |        | out_rendered_nb |              |                   |                             |
|         |                 |                |        | thrice          |              |                   |                             |
|         |                 |                |        | twice           |              |                   |                             |
 --------- ----------------- ---------------- -------- ----------------- -------------- ------------------- ----------------------------- 
| 1       | pm.nb.new.ipynb | python-task    |        |                 |              |                   | 2021-12-22T12:00:05.626048Z |
 --------- ----------------- ---------------- -------- ----------------- -------------- ------------------- ----------------------------- 
```

#### Registration with new passed in version but fails (Confusing at first since version 1 already exists and no version v2 exists for any flyte entities and --version v2 is ignored)

```
flytectl register file  /Users/praful/Downloads/out.tar.gz  -d development  -p chariot-sdk-test  --version v2 --logger.level 2 --archive        
{"json":{"src":"client.go:170"},"level":"error","msg":"failed to initialize token source provider. Err: rpc error: code = Unimplemented desc = unknown service flyteidl.service.AuthMetadataService","ts":"2021-12-22T17:31:25+05:30"}
 ----------------------------------------------------------------------- --------- ----------------- 
| NAME (4)                                                              | STATUS  | ADDITIONAL INFO |
 ----------------------------------------------------------------------- --------- ----------------- 
| /tmp/register1866986520/0_pm.nb.new.ipynb_1.pb                        | Success | AlreadyExists   |
 ----------------------------------------------------------------------- --------- ----------------- 
| /tmp/register1866986520/1_new.ipynb_1.pb                              | Success | AlreadyExists   |
 ----------------------------------------------------------------------- --------- ----------------- 
| /tmp/register1866986520/2_workflows.new_workflow.nb_to_python_wf_2.pb | Success | AlreadyExists   |
 ----------------------------------------------------------------------- --------- ----------------- 
| /tmp/register1866986520/3_workflows.new_workflow.nb_to_python_wf_3.pb | Success | AlreadyExists   |
 ----------------------------------------------------------------------- --------- ----------------- 
```

#### Force registration with v1

```
flytectl register file  /Users/praful/Downloads/out.tar.gz  -d development  -p chariot-sdk-test  --version v1 --logger.level 2 --archive --force
 ----------------------------------------------------------------------- --------- ------------------------------ 
| NAME (4)                                                              | STATUS  | ADDITIONAL INFO              |
 ----------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register2385553692/0_pm.nb.new.ipynb_1.pb                        | Success | Successfully registered file |
 ----------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register2385553692/1_new.ipynb_1.pb                              | Success | Successfully registered file |
 ----------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register2385553692/2_workflows.new_workflow.nb_to_python_wf_2.pb | Success | Successfully registered file |
 ----------------------------------------------------------------------- --------- ------------------------------ 
| /tmp/register2385553692/3_workflows.new_workflow.nb_to_python_wf_3.pb | Success | Successfully registered file |
 ----------------------------------------------------------------------- --------- ------------------------------ 
```

#### Get workflows

```
flytectl get workflow -p chariot-sdk-test -d development --logger.level 6
 --------- ---------------------------------------- ----------------------------- 
| VERSION | NAME                                   | CREATED AT                  |
 --------- ---------------------------------------- ----------------------------- 
| v1      | workflows.new_workflow.nb_to_python_wf | 2021-12-22T12:01:05.244326Z |
 --------- ---------------------------------------- ----------------------------- 
| 1       | workflows.new_workflow.nb_to_python_wf | 2021-12-22T12:00:05.653426Z |
 --------- ---------------------------------------- ----------------------------- 
```

## Type
- [X] Bug Fix
- [X] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1970

## Follow-up issue
_NA_
