### PR TITLE
Updates the local kubecontext with that of sandbox and switches to it

### DIFF
--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -152,14 +152,11 @@ func updateLocalKubeContext() error {
 	if exists {
 		fmt.Printf("context %v already exist. Overwriting it\n", sandboxContextName)
 	} else {
-		delete(localStartingConfig.Contexts, sandboxContextName)
 		localStartingConfig.Contexts[sandboxContextName] = clientcmdapi.NewContext()
 	}
 
-	delete(localStartingConfig.Clusters, sandboxContextName)
 	localStartingConfig.Clusters[sandboxContextName] = dockerStartingConfig.Clusters[sandboxDockerContext]
 	localStartingConfig.Clusters[sandboxContextName].LocationOfOrigin = localConfigAccess.GetDefaultFilename()
-	delete(localStartingConfig.AuthInfos, sandboxContextName)
 	localStartingConfig.AuthInfos[sandboxContextName] = dockerStartingConfig.AuthInfos[sandboxDockerContext]
 	localStartingConfig.AuthInfos[sandboxContextName].LocationOfOrigin = localConfigAccess.GetDefaultFilename()
 	localStartingConfig.Contexts[sandboxContextName].Cluster = sandboxContextName

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -40,17 +40,17 @@ clusters:
       extension:
         audience: foo
         other: bar
-  name: foo-cluster
+  name: default
 contexts:
 - context:
-    cluster: foo-cluster
-    user: foo-user
+    cluster: default
+    user: default
     namespace: bar
-  name: foo-context
-current-context: foo-context
+  name: default
+current-context: default
 kind: Config
 users:
-- name: foo-user
+- name: default
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1

--- a/cmd/sandbox/teardown.go
+++ b/cmd/sandbox/teardown.go
@@ -12,6 +12,8 @@ import (
 	"github.com/enescakir/emoji"
 
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
+	"github.com/flyteorg/flytectl/pkg/k8s"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 const (
@@ -48,6 +50,14 @@ func tearDownSandbox(ctx context.Context, cli docker.Docker) error {
 	if err := configutil.ConfigCleanup(); err != nil {
 		fmt.Printf("Config cleanup failed. Which Failed due to %v \n ", err)
 	}
+	if err := removeSandboxKubeContext(); err != nil {
+		fmt.Printf("Kubecontext cleanup failed. Which Failed due to %v \n ", err)
+	}
 	fmt.Printf("%v %v Sandbox cluster is removed successfully. \n", emoji.Broom, emoji.Broom)
 	return nil
+}
+
+func removeSandboxKubeContext() error {
+	localConfigAccess := clientcmd.NewDefaultPathOptions()
+	return k8s.RemoveKubeContext(localConfigAccess, sandboxContextName)
 }


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR
Current way of using the sandbox kube context is by passing the kubeconfig as parameter

```
kubectl get pods -n flyte  --kubeconfig   /Users/praful/.flyte/k3s/k3s.yaml
```

This PR add the kube context created by k3d in sandbox environment in the local kube context and switches over to it so that users can monitor and check the status of the sandbox directly


```
kubectl get pods -n flyte 
```

It creates a new kube-context with name flyte-sandbox 
Any existing context with the same name would be overwritten


Testing Done:

Started the sandbox and monitored the flyte pods
```
(flyte-started) (base) ➜  flytectl git:(pmahindrakar/1604) ✗ kubectl config current-context
flyte-sandbox
(flyte-started) (base) ➜  flytectl git:(pmahindrakar/1604) ✗ git status                                                                                             
(flyte-started) (base) ➜  flytectl git:(pmahindrakar/1604) ✗ kubectl get pods -n flyte
NAME                                          READY   STATUS      RESTARTS   AGE
flyte-contour-contour-7cfc9f6fb5-8dv4s        1/1     Running     0          7m12s
flyte-kubernetes-dashboard-7fd989b99d-xdj67   1/1     Running     0          7m12s
flyteconsole-7c7698b9fc-vpqdl                 1/1     Running     0          7m12s
postgres-6485776865-mfmqc                     1/1     Running     0          7m12s
flytepropeller-6fdf748d5-dgxkt                1/1     Running     0          7m12s
minio-65fbb69485-4lrvq                        1/1     Running     0          7m12s
flyte-pod-webhook-67446897d6-td8kn            1/1     Running     0          7m12s
datacatalog-589d78fc57-bbdrr                  1/1     Running     0          7m12s
flyte-contour-envoy-trblm                     2/2     Running     0          7m12s
flyteadmin-bc9bd4cb9-hn6jf                    2/2     Running     0          7m12s
flytescheduler-795fdf957f-9btzd               1/1     Running     0          7m12s
syncresources-27349085-trflc                  0/1     Completed   0          2m10s
syncresources-27349086-vfqs6                  0/1     Completed   0          70s
syncresources-27349087-kcclj                  0/1     Completed   0          10s
```


### Sandbox teardown removes the context and unsets the current context

```
(base) ➜  flytectl git:(pmahindrakar/1604) ✗ flytectl sandbox teardown
(base) ➜  flytectl git:(pmahindrakar/1604) ✗ kubectl config current-context
flyte-sandbox
(base) ➜  flytectl git:(pmahindrakar/1604) ✗ flytectl sandbox teardown
context removed for "flyte-sandbox".
🧹 🧹 Sandbox cluster is removed successfully. 
(base) ➜  flytectl git:(pmahindrakar/1604) ✗ kubectl config current-context     
error: current-context is not set
```

## Type
- [ ] Bug Fix
- [X] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1604

## Follow-up issue
_NA_
