### PR TITLE
bump docsearch version

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -13,9 +13,9 @@ beautifulsoup4==4.10.0
     #   furo
     #   sphinx-code-include
     #   sphinx-material
-certifi==2021.5.30
+certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.4
+charset-normalizer==2.0.10
     # via requests
 css-html-js-minify==2.5.5
     # via sphinx-material
@@ -23,39 +23,39 @@ docutils==0.17.1
     # via
     #   sphinx
     #   sphinx-panels
-git+git://github.com/flyteorg/furo@main
+furo @ git+git://github.com/flyteorg/furo@main
     # via -r doc-requirements.in
-idna==3.2
+idna==3.3
     # via requests
-imagesize==1.2.0
+imagesize==1.3.0
     # via sphinx
-jinja2==3.0.1
+jinja2==3.0.3
     # via sphinx
-lxml==4.6.5
+lxml==4.7.1
     # via sphinx-material
 markupsafe==2.0.1
     # via jinja2
-packaging==21.0
+packaging==21.3
     # via sphinx
-pygments==2.10.0
+pygments==2.11.2
     # via
     #   sphinx
     #   sphinx-prompt
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 python-slugify[unidecode]==5.0.2
     # via sphinx-material
-pytz==2021.1
+pytz==2021.3
     # via babel
-requests==2.26.0
+requests==2.27.1
     # via sphinx
 six==1.16.0
     # via sphinx-code-include
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.2.1
+soupsieve==2.3.1
     # via beautifulsoup4
-sphinx==4.1.2
+sphinx==4.3.2
     # via
     #   -r doc-requirements.in
     #   furo
@@ -72,7 +72,7 @@ sphinx-copybutton==0.4.0
     # via -r doc-requirements.in
 sphinx-fontawesome==0.0.6
     # via -r doc-requirements.in
-sphinx-material==0.0.34
+sphinx-material==0.0.35
     # via -r doc-requirements.in
 sphinx-panels==0.6.0
     # via -r doc-requirements.in
@@ -94,9 +94,9 @@ sphinxcontrib-yt==0.2.2
     # via -r doc-requirements.in
 text-unidecode==1.3
     # via python-slugify
-unidecode==1.3.0
+unidecode==1.3.2
     # via python-slugify
-urllib3==1.26.6
+urllib3==1.26.7
     # via requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

## Read then delete

- Make sure to use a concise title for the pull-request.
- Use #patch, #minor #majora or #none in the pull-request title to bump the corresponding version. Otherwise, the patch version
  will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)

# TL;DR
- Pull updated Algolia search creds from furo repo
- Bump docsearch from v2 to v3

<img width="1362" alt="Screenshot 2022-01-07 at 4 18 37 PM" src="https://user-images.githubusercontent.com/27777173/148533760-dfb675f0-ed21-46c7-9526-117c3e82bfc3.png">

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2030

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
