### PR TITLE
Added endpoint suffix to service user for pkce token saved in token cache

### DIFF
--- a/cmd/core/cmd.go
+++ b/cmd/core/cmd.go
@@ -61,7 +61,7 @@ func generateCommandFunc(cmdEntry CommandEntry) func(cmd *cobra.Command, args []
 		adminCfg := admin.GetConfig(ctx)
 		clientSet, err := admin.ClientSetBuilder().WithConfig(admin.GetConfig(ctx)).
 			WithTokenCache(pkce.TokenCacheKeyringProvider{
-				ServiceUser: adminCfg.Endpoint.String() + ":" + pkce.KeyRingServiceUser,
+				ServiceUser: fmt.Sprintf("%s:%s", adminCfg.Endpoint.String(), pkce.KeyRingServiceUser),
 				ServiceName: pkce.KeyRingServiceName,
 			}).Build(ctx)
 		if err != nil {

--- a/cmd/core/cmd.go
+++ b/cmd/core/cmd.go
@@ -58,9 +58,10 @@ func generateCommandFunc(cmdEntry CommandEntry) func(cmd *cobra.Command, args []
 			return err
 		}
 
+		adminCfg := admin.GetConfig(ctx)
 		clientSet, err := admin.ClientSetBuilder().WithConfig(admin.GetConfig(ctx)).
 			WithTokenCache(pkce.TokenCacheKeyringProvider{
-				ServiceUser: pkce.KeyRingServiceUser,
+				ServiceUser: adminCfg.Endpoint.String() + ":" + pkce.KeyRingServiceUser,
 				ServiceName: pkce.KeyRingServiceName,
 			}).Build(ctx)
 		if err != nil {

--- a/cmd/core/cmd_test.go
+++ b/cmd/core/cmd_test.go
@@ -1,0 +1,27 @@
+package cmdcore
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/flyteorg/flyteidl/clients/go/admin"
+	"github.com/flyteorg/flytestdlib/config"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func testCommandFunc(ctx context.Context, args []string, cmdCtx CommandContext) error {
+	return nil
+}
+
+func TestGenerateCommandFunc(t *testing.T) {
+	adminCfg := admin.GetConfig(context.Background())
+	adminCfg.Endpoint = config.URL{URL: url.URL{Host: "dummyHost"}}
+	adminCfg.AuthType = admin.AuthTypePkce
+	rootCmd := &cobra.Command{}
+	cmdEntry := CommandEntry{CmdFunc: testCommandFunc, ProjectDomainNotRequired: true}
+	fn := generateCommandFunc(cmdEntry)
+	assert.Nil(t, fn(rootCmd, []string{}))
+}


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

Add an endpoint suffix to pkce token cache provider user name


### Before the change 
On mac key chain which is used for token cache had the following entry

<img width="534" alt="Screenshot 2022-01-12 at 7 00 58 PM" src="https://user-images.githubusercontent.com/77798312/149149923-b4bcfcfa-af21-4a74-b756-eef2f603fdd9.png">


### After the change key chain entry

#### for  config.yaml with host : demo.nuclyde.io
<img width="527" alt="Screenshot 2022-01-12 at 7 01 05 PM" src="https://user-images.githubusercontent.com/77798312/149149978-1a5a6173-8361-4ee2-8b0d-b76ea4bafba3.png">


#### for  config.yaml with host : sample-tenant.cloud-staging.union.ai

<img width="530" alt="Screenshot 2022-01-12 at 7 01 45 PM" src="https://user-images.githubusercontent.com/77798312/149150182-08eb8bf5-a6d1-4f24-b5ed-cfd8fa388981.png">



### Testing done

*  Change config.yaml to use demo.nuclyde.io and fetched projects
Verified new entry created for cache after new token is fetched from the provider


* fetched projects with unchanged config.yaml
Verified cache entry is reused and browser is not opened


* Change config.yaml to use sample-tenant.staging.union.ai and fetched projects
Verified new entry created for cache after new token is fetched from the provider

* fetched projects with unchanged config.yaml
Verified cache entry is reused and browser is not opened

* Deleted the cache entry for demo.nuclyde with  sample-tenant.staging.union.ai  config
Verified cache entry is reused and browser is not opened 


## Type
- [ ] Bug Fix
- [X] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [X] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1962 
## Follow-up issue
_NA_

