### PR TITLE
Fix gRPC init configuration

### DIFF
--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -58,7 +58,7 @@ var prompt = promptui.Select{
 	Items: []string{"S3", "GCS"},
 }
 
-var endpointPrefix = [3]string{"dns://", "http://", "https://"}
+var endpointPrefix = [3]string{"dns:///", "http://", "https://"}
 
 // CreateConfigCommand will return configuration command
 func CreateConfigCommand() *cobra.Command {
@@ -95,7 +95,7 @@ func initFlytectlConfig(ctx context.Context, reader io.Reader) error {
 		if !validateEndpointName(trimHost) {
 			return errors.New("Please use a valid endpoint")
 		}
-		templateValues.Host = fmt.Sprintf("dns://%s", trimHost)
+		templateValues.Host = fmt.Sprintf("dns:///%s", trimHost)
 		templateValues.Insecure = initConfig.DefaultConfig.Insecure
 		templateStr = configutil.AdminConfigTemplate
 		if initConfig.DefaultConfig.Storage {

--- a/cmd/configuration/configuration_test.go
+++ b/cmd/configuration/configuration_test.go
@@ -65,7 +65,7 @@ func TestSetupConfigFunc(t *testing.T) {
 }
 
 func TestTrimFunc(t *testing.T) {
-	assert.Equal(t, trimEndpoint("dns://localhost"), "localhost")
+	assert.Equal(t, trimEndpoint("dns:///localhost"), "localhost")
 	assert.Equal(t, trimEndpoint("http://localhost"), "localhost")
 	assert.Equal(t, trimEndpoint("https://localhost"), "localhost")
 }


### PR DESCRIPTION
## Read then delete

- Make sure to use a concise title for the pull-request.
- Use #patch, #minor #majora or #none in the pull-request title to bump the corresponding version. Otherwise, the patch version
  will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)

# TL;DR
The `config init` generate an invalid url:
```bash
$ flytectl config init --host='localhost:30081'
$ head ~/.flyte/config.yaml 
admin:
  # For GRPC endpoints you might want to use dns:///flyte.myexample.com
  endpoint: dns://localhost:30081
  authType: Pkce
  insecure: true
```
took some minutes to notice was missing an '/' in the `endpoint` :sweat_smile: 
## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Adde one more '/' in the configuration for `dns` (gRPC) protocol.
