### PR TITLE
Fixed create project

### DIFF
--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -3,7 +3,7 @@ package clierrors
 var (
 	ErrInvalidStateUpdate = "Invalid state passed. Specify either activate or archive\n"
 
-	ErrProjectNotPassed     = "Project not passed\n"
+	ErrProjectNotPassed     = "Project id not passed\n" // #nosec
 	ErrProjectNameNotPassed = "project name is required flag"
 	ErrFailedProjectUpdate  = "Project %v failed to get updated due to %v\n"
 

--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -56,6 +56,10 @@ func (c *ConfigProject) GetProjectSpec(id string) (*admin.Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		if projectSpec.Id == id {
+			return &projectSpec, nil
+		}
+		projectSpec.Id = id
 		return &projectSpec, nil
 	}
 

--- a/cmd/create/project.go
+++ b/cmd/create/project.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flytectl/clierrors"
-	"github.com/flyteorg/flytectl/cmd/config"
-
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 
@@ -41,7 +39,7 @@ Create a project by definition file. Note: The name shouldn't contain any whites
 )
 
 func createProjectsCommand(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(config.GetConfig().Project)
+	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(project.DefaultProjectConfig.ID)
 	if err != nil {
 		return err
 	}

--- a/cmd/create/project_test.go
+++ b/cmd/create/project_test.go
@@ -62,7 +62,7 @@ func TestEmptyProjectID(t *testing.T) {
 	project.DefaultProjectConfig = &project.ConfigProject{}
 	mockClient.OnRegisterProjectMatch(ctx, projectRegisterRequest).Return(nil, nil)
 	err := createProjectsCommand(ctx, args, cmdCtx)
-	assert.Equal(t, errors.New(clierrors.ErrProjectNameNotPassed), err)
+	assert.Equal(t, errors.New(clierrors.ErrProjectNotPassed), err)
 	mockClient.AssertNotCalled(t, "RegisterProject", ctx, mock.Anything)
 }
 

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -88,11 +88,11 @@ func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comma
 	if err != nil {
 		return err
 	}
-	if projectSpec.Id == "" {
+	if projectSpec.Id != config.GetConfig().Project {
 		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}
-	if projectSpec.Name == "" {
-		return fmt.Errorf(clierrors.ErrProjectNameNotPassed)
+	if projectSpec.Id == "" {
+		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}
 
 	state, err := project.DefaultProjectConfig.MapToAdminState()

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -88,9 +88,6 @@ func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comma
 	if err != nil {
 		return err
 	}
-	if projectSpec.Id != config.GetConfig().Project {
-		return fmt.Errorf(clierrors.ErrProjectNotPassed)
-	}
 	if projectSpec.Id == "" {
 		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}


### PR DESCRIPTION
# TL;DR
- Removed project id validation from create project,  Currently we have a check on project ID

Test:

```
20:55:28 ➜ flytectl go run main.go create project --name myproj --id myproj
project Created successfully
20:55:52 ➜ flytectl go run main.go get project  myproj -o yaml > test.yaml 
20:55:28 ➜  cat test.yaml
domains:
- id: development
  name: development
- id: staging
  name: staging
- id: production
  name: production
id: myproj
labels: {}
name: myproj



# Update File With Wrong id 
domains:
- id: development
  name: development
- id: staging
  name: staging
- id: production
  name: production
id: myp
labels: {}
name: myproj

20:56:28 ➜ flytectl go run main.go update project -p myproj --file test.yaml
Project myproj updated


description: kjdfjksdjkfhkjdshjf
domains:
- id: development
  name: development
- id: staging
  name: staging
- id: production
  name: production
id: myproj
labels: {}
name: mypro


```
## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2144

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
