### PR TITLE
Use GetLatestRelease to list latest non-pre-release flytesnacks version #minor

### DIFF
--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -561,20 +561,11 @@ func getAllExample(repository, version string) ([]*github.ReleaseAsset, *github.
 		}
 		return filterExampleFromRelease(release), release, nil
 	}
-	releases, err := githubutil.GetListRelease(repository)
+	release, err := githubutil.GetLatestRelease(repository)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(releases) == 0 {
-		return nil, nil, fmt.Errorf("repository doesn't have any release")
-	}
-	for _, v := range releases {
-		if !*v.Prerelease {
-			return filterExampleFromRelease(v), v, nil
-		}
-	}
-	return nil, nil, nil
-
+	return filterExampleFromRelease(release), release, nil
 }
 
 func getRemoteStoragePath(ctx context.Context, s *storage.DataStore, remoteLocation, file, identifier string) (storage.DataReference, error) {

--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -561,7 +561,7 @@ func getAllExample(repository, version string) ([]*github.ReleaseAsset, *github.
 		}
 		return filterExampleFromRelease(release), release, nil
 	}
-	release, err := githubutil.GetLatestRelease(repository)
+	release, err := githubutil.GetLatestVersion(repository)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/util/githubutil/githubutil.go
+++ b/pkg/util/githubutil/githubutil.go
@@ -65,6 +65,17 @@ func GetGHClient() *github.Client {
 	return github.NewClient(&http.Client{})
 }
 
+// GetLatestVersion returns the latest non-prerelease version of provided repository, as
+// described in https://docs.github.com/en/rest/reference/releases#get-the-latest-release
+func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
+	client := GetGHClient()
+	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
+	if err != nil {
+		return nil, err
+	}
+	return release, err
+}
+
 // GetListRelease returns the list of release of provided repository
 func GetListRelease(repository string) ([]*github.RepositoryRelease, error) {
 	client := GetGHClient()
@@ -75,17 +86,6 @@ func GetListRelease(repository string) ([]*github.RepositoryRelease, error) {
 		return nil, err
 	}
 	return releases, err
-}
-
-// GetLatestVersion returns the latest non-prerelease version of provided repository, as
-// described in https://docs.github.com/en/rest/reference/releases#get-the-latest-release
-func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
-	client := GetGHClient()
-	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
-	if err != nil {
-		return nil, err
-	}
-	return release, err
 }
 
 // GetSandboxImageSha returns the sha as per input

--- a/pkg/util/githubutil/githubutil.go
+++ b/pkg/util/githubutil/githubutil.go
@@ -65,17 +65,21 @@ func GetGHClient() *github.Client {
 	return github.NewClient(&http.Client{})
 }
 
-// GetLatestVersion returns the latest version of provided repository
-func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
+// GetListRelease returns the list of release of provided repository
+func GetListRelease(repository string) ([]*github.RepositoryRelease, error) {
 	client := GetGHClient()
-	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
+	releases, _, err := client.Repositories.ListReleases(context.Background(), owner, repository, &github.ListOptions{
+		PerPage: 100,
+	})
 	if err != nil {
 		return nil, err
 	}
-	return release, err
+	return releases, err
 }
 
-func GetLatestRelease(repository string) (*github.RepositoryRelease, error) {
+// GetLatestVersion returns the latest non-prerelease version of provided repository, as
+// described in https://docs.github.com/en/rest/reference/releases#get-the-latest-release
+func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
 	client := GetGHClient()
 	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
 	if err != nil {

--- a/pkg/util/githubutil/githubutil.go
+++ b/pkg/util/githubutil/githubutil.go
@@ -75,16 +75,13 @@ func GetLatestVersion(repository string) (*github.RepositoryRelease, error) {
 	return release, err
 }
 
-// GetListRelease returns the list of release of provided repository
-func GetListRelease(repository string) ([]*github.RepositoryRelease, error) {
+func GetLatestRelease(repository string) (*github.RepositoryRelease, error) {
 	client := GetGHClient()
-	releases, _, err := client.Repositories.ListReleases(context.Background(), owner, repository, &github.ListOptions{
-		PerPage: 100,
-	})
+	release, _, err := client.Repositories.GetLatestRelease(context.Background(), owner, repository)
 	if err != nil {
 		return nil, err
 	}
-	return releases, err
+	return release, err
 }
 
 // GetSandboxImageSha returns the sha as per input


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Use github API to fetch latest non-prerelease version instead of doing that filtering manually

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Github offers an API to ensure we get the latest non-prerelease version. In this PR we adopt that API instead of manually filtering out the release versions. This is the api mentioned in https://github.com/flyteorg/flyte/issues/2168#issuecomment-1040903297.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2168

## Follow-up issue
_NA_
