### PR TITLE
Grammatical correction for 'already on latest version message' in 'upgrade.go'

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -115,7 +115,7 @@ func isUpgradeSupported(goos platformutil.Platform) (bool, error) {
 	if isGreater, err := util.IsVersionGreaterThan(latest, stdlibversion.Version); err != nil {
 		return false, err
 	} else if !isGreater {
-		fmt.Println("You have already latest version of flytectl")
+		fmt.Println("You already have the latest version of flytectl")
 		return false, nil
 	}
 


### PR DESCRIPTION
## Read then delete

- Make sure to use a concise title for the pull-request.
- Use #patch, #minor #majora or #none in the pull-request title to bump the corresponding version. Otherwise, the patch version
  will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)

# TL;DR
Fixed grammatical issue in 'latest version' message.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Fixed grammatical issue in 'latest version' message in `upgrade.go`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
