### PR TITLE
Env variable added for sandbox wait timeout

### DIFF
--- a/cmd/config/subcommand/sandbox/config_flags.go
+++ b/cmd/config/subcommand/sandbox/config_flags.go
@@ -55,5 +55,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.StringVar(&DefaultConfig.Image, fmt.Sprintf("%v%v", prefix, "image"), DefaultConfig.Image, "Optional. Provide a fully qualified path to a Flyte compliant docker image.")
 	cmdFlags.BoolVar(&DefaultConfig.Prerelease, fmt.Sprintf("%v%v", prefix, "pre"), DefaultConfig.Prerelease, "Optional. Pre release Version of flyte will be used for sandbox.")
 	cmdFlags.Var(&DefaultConfig.ImagePullPolicy, fmt.Sprintf("%v%v", prefix, "imagePullPolicy"), "Optional. Defines the image pull behavior [Always/IfNotPresent/Never]")
+	cmdFlags.Int64Var(&DefaultConfig.Timeout, fmt.Sprintf("%v%v", prefix, "timeout"), DefaultConfig.Timeout, "Optional. Timeout to wait for Flyte deployment,  default is 600s.")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/sandbox/config_flags_test.go
+++ b/cmd/config/subcommand/sandbox/config_flags_test.go
@@ -167,4 +167,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_timeout", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("timeout", testValue)
+			if vInt64, err := cmdFlags.GetInt64("timeout"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vInt64), &actual.Timeout)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/cmd/config/subcommand/sandbox/sandbox_config.go
+++ b/cmd/config/subcommand/sandbox/sandbox_config.go
@@ -50,4 +50,8 @@ type Config struct {
 	// Optionally it is possible to use local sandbox image
 	// If local flag pass then flytectl will not pull image from registry. Usually useful, if you want to test your local images without pushing them to a registry
 	ImagePullPolicy ImagePullPolicy `json:"imagePullPolicy" pflag:",Optional. Defines the image pull behavior [Always/IfNotPresent/Never]"`
+
+	// Optionally it is possible to specify a timeout for Flyte deployment
+	// Default values is 600s(10m)
+	Timeout int64 `json:"timeout" pflag:",Optional. Timeout to wait for Flyte deployment, default is 600s."`
 }

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -70,6 +70,11 @@ Specify a Flyte Sandbox image pull policy. Possible pull policy values are Alway
 ::
 
  flytectl sandbox start  --image docker.io/my-override:latest --imagePullPolicy Always
+
+Specify custom timeout to wait for flyte deployment, By default it is 600s(10m) :
+::
+
+ flytectl sandbox start  --timeout=800
 Usage
 `
 	k8sEndpoint          = "https://127.0.0.1:30086"
@@ -182,7 +187,7 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 
 	fmt.Printf("%v booting Flyte-sandbox container\n", emoji.FactoryWorker)
 	exposedPorts, portBindings, _ := docker.GetSandboxPorts()
-	ID, err := docker.StartContainer(ctx, cli, volumes, exposedPorts, portBindings, docker.FlyteSandboxClusterName, sandboxImage)
+	ID, err := docker.StartContainer(ctx, cli, volumes, exposedPorts, portBindings, docker.FlyteSandboxClusterName, sandboxImage, sandboxConfig.DefaultConfig.Timeout)
 	if err != nil {
 		fmt.Printf("%v Something went wrong: Failed to start Sandbox container %v, Please check your docker client and try again. \n", emoji.GrimacingFace, emoji.Whale)
 		return nil, err

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -131,7 +131,10 @@ func PullDockerImage(ctx context.Context, cli Docker, image string, pullPolicy s
 }
 
 //StartContainer will create and start docker container
-func StartContainer(ctx context.Context, cli Docker, volumes []mount.Mount, exposedPorts map[nat.Port]struct{}, portBindings map[nat.Port][]nat.PortBinding, name, image string) (string, error) {
+func StartContainer(ctx context.Context, cli Docker, volumes []mount.Mount, exposedPorts map[nat.Port]struct{}, portBindings map[nat.Port][]nat.PortBinding, name, image string, timeout int64) (string, error) {
+	if timeout > 0 {
+		Environment = append(Environment, fmt.Sprintf("FLYTE_TIMEOUT=%d", timeout))
+	}
 	resp, err := cli.ContainerCreate(ctx, &container.Config{
 		Env:          Environment,
 		Image:        image,

--- a/pkg/docker/docker_util_test.go
+++ b/pkg/docker/docker_util_test.go
@@ -166,7 +166,7 @@ func TestStartContainer(t *testing.T) {
 			ID: "Hello",
 		}, nil)
 		mockDocker.OnContainerStart(context, "Hello", types.ContainerStartOptions{}).Return(nil)
-		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName)
+		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName, 0)
 		assert.Nil(t, err)
 		assert.Greater(t, len(id), 0)
 		assert.Equal(t, id, "Hello")
@@ -191,7 +191,7 @@ func TestStartContainer(t *testing.T) {
 			ID: "",
 		}, fmt.Errorf("error"))
 		mockDocker.OnContainerStart(context, "Hello", types.ContainerStartOptions{}).Return(nil)
-		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName)
+		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName, 0)
 		assert.NotNil(t, err)
 		assert.Equal(t, len(id), 0)
 		assert.Equal(t, id, "")
@@ -216,7 +216,7 @@ func TestStartContainer(t *testing.T) {
 			ID: "Hello",
 		}, nil)
 		mockDocker.OnContainerStart(context, "Hello", types.ContainerStartOptions{}).Return(fmt.Errorf("error"))
-		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName)
+		id, err := StartContainer(context, mockDocker, Volumes, p1, p2, "nginx", imageName, 0)
 		assert.NotNil(t, err)
 		assert.Equal(t, len(id), 0)
 		assert.Equal(t, id, "")


### PR DESCRIPTION
# TL;DR
- Added timeout flag for sandbox, Timeout to wait for Flyte Deployment, Default is 600s. (https://github.com/flyteorg/flyte/pull/2226)

Tested locally with sandbox image 

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2197

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
