### PR TITLE
Added workflow flag for get launchplan

### DIFF
--- a/cmd/config/subcommand/launchplan/config_flags.go
+++ b/cmd/config/subcommand/launchplan/config_flags.go
@@ -58,5 +58,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.Int32Var(&DefaultConfig.Filter.Limit, fmt.Sprintf("%v%v", prefix, "filter.limit"), DefaultConfig.Filter.Limit, "Specifies the limit")
 	cmdFlags.BoolVar(&DefaultConfig.Filter.Asc, fmt.Sprintf("%v%v", prefix, "filter.asc"), DefaultConfig.Filter.Asc, "Specifies the sorting order. By default flytectl sort result in descending order")
 	cmdFlags.Int32Var(&DefaultConfig.Filter.Page, fmt.Sprintf("%v%v", prefix, "filter.page"), DefaultConfig.Filter.Page, "Specifies the page number,  in case there are multiple pages of results")
+	cmdFlags.StringVar(&DefaultConfig.Workflow, fmt.Sprintf("%v%v", prefix, "workflow"), DefaultConfig.Workflow, "name of the workflow for which the launchplans need to be fetched.")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/launchplan/config_flags_test.go
+++ b/cmd/config/subcommand/launchplan/config_flags_test.go
@@ -211,4 +211,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_workflow", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("workflow", testValue)
+			if vString, err := cmdFlags.GetString("workflow"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.Workflow)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/cmd/config/subcommand/launchplan/launchplan_config.go
+++ b/cmd/config/subcommand/launchplan/launchplan_config.go
@@ -17,4 +17,5 @@ type Config struct {
 	Version  string          `json:"version" pflag:",version of the launchplan to be fetched."`
 	Latest   bool            `json:"latest" pflag:", flag to indicate to fetch the latest version, version flag will be ignored in this case"`
 	Filter   filters.Filters `json:"filter" pflag:","`
+	Workflow string          `json:"workflow" pflag:",name of the workflow for which the launchplans need to be fetched."`
 }

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -40,6 +40,12 @@ Retrieve a particular version of the launch plan by name within the project and 
 
  flytectl get launchplan -p flytesnacks -d development  core.basic.lp.go_greet --version v2
 
+Retrieve all launch plans for a given workflow name:
+
+::
+
+ flytectl get launchplan -p flytesnacks -d development --workflow core.flyte_basics.lp.go_greet
+
 Retrieve all the launch plans with filters:
 ::
 
@@ -173,6 +179,17 @@ func getLaunchPlanFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 	launchPlans, err := cmdCtx.AdminFetcherExt().FetchAllVerOfLP(ctx, "", config.GetConfig().Project, config.GetConfig().Domain, launchplan.DefaultConfig.Filter)
 	if err != nil {
 		return err
+	}
+
+	workflowName := launchplan.DefaultConfig.Workflow
+	var workflowFilteredLps []*admin.LaunchPlan
+	if len(launchplan.DefaultConfig.Workflow) > 0 {
+		for _, lp := range launchPlans {
+			if lp.Spec.WorkflowId.Name == workflowName {
+				workflowFilteredLps = append(workflowFilteredLps, lp)
+			}
+		}
+		launchPlans = workflowFilteredLps
 	}
 
 	logger.Debugf(ctx, "Retrieved %v launch plans", len(launchPlans))

--- a/cmd/get/launch_plan_test.go
+++ b/cmd/get/launch_plan_test.go
@@ -23,14 +23,15 @@ import (
 )
 
 var (
-	resourceListRequest    *admin.ResourceListRequest
-	resourceGetRequest     *admin.ResourceListRequest
-	objectGetRequest       *admin.ObjectGetRequest
-	namedIDRequest         *admin.NamedEntityIdentifierListRequest
-	launchPlanListResponse *admin.LaunchPlanList
-	argsLp                 []string
-	namedIdentifierList    *admin.NamedEntityIdentifierList
-	launchPlan2            *admin.LaunchPlan
+	resourceListRequest            *admin.ResourceListRequest
+	resourceGetRequest             *admin.ResourceListRequest
+	objectGetRequest               *admin.ObjectGetRequest
+	namedIDRequest                 *admin.NamedEntityIdentifierListRequest
+	launchPlanListResponse         *admin.LaunchPlanList
+	filteredLaunchPlanListResponse *admin.LaunchPlanList
+	argsLp                         []string
+	namedIdentifierList            *admin.NamedEntityIdentifierList
+	launchPlan2                    *admin.LaunchPlan
 )
 
 func getLaunchPlanSetup() {
@@ -150,6 +151,10 @@ func getLaunchPlanSetup() {
 
 	launchPlanListResponse = &admin.LaunchPlanList{
 		LaunchPlans: launchPlans,
+	}
+
+	filteredLaunchPlanListResponse = &admin.LaunchPlanList{
+		LaunchPlans: []*admin.LaunchPlan{launchPlan2},
 	}
 
 	objectGetRequest = &admin.ObjectGetRequest{
@@ -289,7 +294,6 @@ func TestGetLaunchPlans(t *testing.T) {
 		setup()
 		getLaunchPlanSetup()
 		mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(launchPlanListResponse, nil)
-		mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
 		argsLp = []string{}
 		err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 		assert.Nil(t, err)
@@ -298,13 +302,23 @@ func TestGetLaunchPlans(t *testing.T) {
 	t.Run("workflow filter", func(t *testing.T) {
 		setup()
 		getLaunchPlanSetup()
-		mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(launchPlanListResponse, nil)
-		mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
+		resourceListRequest.Filters = "eq(workflow.name,workflow2)"
+		mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(filteredLaunchPlanListResponse, nil)
 		argsLp = []string{}
 		launchplan.DefaultConfig.Workflow = "workflow2"
 		err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 		assert.Nil(t, err)
 		tearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
+	})
+	t.Run("workflow filter error", func(t *testing.T) {
+		setup()
+		getLaunchPlanSetup()
+		argsLp = []string{}
+		launchplan.DefaultConfig.Workflow = "workflow2"
+		launchplan.DefaultConfig.Filter.FieldSelector = "workflow.name"
+		err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
+		assert.NotNil(t, err)
+		assert.Equal(t, fmt.Errorf("fieldSelector cannot be specified with workflow flag"), err)
 	})
 }
 

--- a/cmd/get/launch_plan_test.go
+++ b/cmd/get/launch_plan_test.go
@@ -96,6 +96,9 @@ func getLaunchPlanSetup() {
 			Version: "v1",
 		},
 		Spec: &admin.LaunchPlanSpec{
+			WorkflowId: &core.Identifier{
+				Name: "workflow1",
+			},
 			DefaultInputs: &core.ParameterMap{
 				Parameters: parameterMap,
 			},
@@ -113,6 +116,9 @@ func getLaunchPlanSetup() {
 			Version: "v2",
 		},
 		Spec: &admin.LaunchPlanSpec{
+			WorkflowId: &core.Identifier{
+				Name: "workflow2",
+			},
 			DefaultInputs: &core.ParameterMap{
 				Parameters: parameterMap,
 			},
@@ -249,178 +255,7 @@ func TestGetLaunchPlanFunc(t *testing.T) {
 	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 	assert.Nil(t, err)
 	mockClient.AssertCalled(t, "ListLaunchPlans", ctx, resourceGetRequest)
-	tearDownAndVerify(t, `[
-	{
-		"id": {
-			"name": "launchplan1",
-			"version": "v2"
-		},
-		"spec": {
-			"defaultInputs": {
-				"parameters": {
-					"numbers": {
-						"var": {
-							"type": {
-								"collectionType": {
-									"simple": "INTEGER"
-								}
-							},
-							"description": "short desc"
-						}
-					},
-					"numbers_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "long description will be truncated in table"
-						}
-					},
-					"run_local_at_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "run_local_at_count"
-						},
-						"default": {
-							"scalar": {
-								"primitive": {
-									"integer": "10"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"closure": {
-			"expectedInputs": {
-				"parameters": {
-					"numbers": {
-						"var": {
-							"type": {
-								"collectionType": {
-									"simple": "INTEGER"
-								}
-							},
-							"description": "short desc"
-						}
-					},
-					"numbers_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "long description will be truncated in table"
-						}
-					},
-					"run_local_at_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "run_local_at_count"
-						},
-						"default": {
-							"scalar": {
-								"primitive": {
-									"integer": "10"
-								}
-							}
-						}
-					}
-				}
-			},
-			"createdAt": "1970-01-01T00:00:01Z"
-		}
-	},
-	{
-		"id": {
-			"name": "launchplan1",
-			"version": "v1"
-		},
-		"spec": {
-			"defaultInputs": {
-				"parameters": {
-					"numbers": {
-						"var": {
-							"type": {
-								"collectionType": {
-									"simple": "INTEGER"
-								}
-							},
-							"description": "short desc"
-						}
-					},
-					"numbers_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "long description will be truncated in table"
-						}
-					},
-					"run_local_at_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "run_local_at_count"
-						},
-						"default": {
-							"scalar": {
-								"primitive": {
-									"integer": "10"
-								}
-							}
-						}
-					}
-				}
-			}
-		},
-		"closure": {
-			"expectedInputs": {
-				"parameters": {
-					"numbers": {
-						"var": {
-							"type": {
-								"collectionType": {
-									"simple": "INTEGER"
-								}
-							},
-							"description": "short desc"
-						}
-					},
-					"numbers_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "long description will be truncated in table"
-						}
-					},
-					"run_local_at_count": {
-						"var": {
-							"type": {
-								"simple": "INTEGER"
-							},
-							"description": "run_local_at_count"
-						},
-						"default": {
-							"scalar": {
-								"primitive": {
-									"integer": "10"
-								}
-							}
-						}
-					}
-				}
-			},
-			"createdAt": "1970-01-01T00:00:00Z"
-		}
-	}
-]`)
+	tearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
 }
 
 func TestGetLaunchPlanFuncLatest(t *testing.T) {
@@ -433,91 +268,7 @@ func TestGetLaunchPlanFuncLatest(t *testing.T) {
 	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 	assert.Nil(t, err)
 	mockClient.AssertCalled(t, "ListLaunchPlans", ctx, resourceGetRequest)
-	tearDownAndVerify(t, `{
-	"id": {
-		"name": "launchplan1",
-		"version": "v2"
-	},
-	"spec": {
-		"defaultInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"closure": {
-		"expectedInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		},
-		"createdAt": "1970-01-01T00:00:01Z"
-	}
-}`)
+	tearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
 }
 
 func TestGetLaunchPlanWithVersion(t *testing.T) {
@@ -530,102 +281,31 @@ func TestGetLaunchPlanWithVersion(t *testing.T) {
 	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
 	assert.Nil(t, err)
 	mockClient.AssertCalled(t, "GetLaunchPlan", ctx, objectGetRequest)
-	tearDownAndVerify(t, `{
-	"id": {
-		"name": "launchplan1",
-		"version": "v2"
-	},
-	"spec": {
-		"defaultInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"closure": {
-		"expectedInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		},
-		"createdAt": "1970-01-01T00:00:01Z"
-	}
-}`)
+	tearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
 }
 
 func TestGetLaunchPlans(t *testing.T) {
-	setup()
-	getLaunchPlanSetup()
-	mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(launchPlanListResponse, nil)
-	mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
-	argsLp = []string{}
-	err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
-	assert.Nil(t, err)
-	tearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
+	t.Run("no workflow filter", func(t *testing.T) {
+		setup()
+		getLaunchPlanSetup()
+		mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(launchPlanListResponse, nil)
+		mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
+		argsLp = []string{}
+		err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
+		assert.Nil(t, err)
+		tearDownAndVerify(t, `[{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}},{"id": {"name": "launchplan1","version": "v1"},"spec": {"workflowId": {"name": "workflow1"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:00Z"}}]`)
+	})
+	t.Run("workflow filter", func(t *testing.T) {
+		setup()
+		getLaunchPlanSetup()
+		mockClient.OnListLaunchPlansMatch(ctx, resourceListRequest).Return(launchPlanListResponse, nil)
+		mockClient.OnGetLaunchPlanMatch(ctx, objectGetRequest).Return(launchPlan2, nil)
+		argsLp = []string{}
+		launchplan.DefaultConfig.Workflow = "workflow2"
+		err = getLaunchPlanFunc(ctx, argsLp, cmdCtx)
+		assert.Nil(t, err)
+		tearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
+	})
 }
 
 func TestGetLaunchPlansWithExecFile(t *testing.T) {
@@ -640,91 +320,7 @@ func TestGetLaunchPlansWithExecFile(t *testing.T) {
 	os.Remove(launchplan.DefaultConfig.ExecFile)
 	assert.Nil(t, err)
 	mockClient.AssertCalled(t, "GetLaunchPlan", ctx, objectGetRequest)
-	tearDownAndVerify(t, `{
-	"id": {
-		"name": "launchplan1",
-		"version": "v2"
-	},
-	"spec": {
-		"defaultInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"closure": {
-		"expectedInputs": {
-			"parameters": {
-				"numbers": {
-					"var": {
-						"type": {
-							"collectionType": {
-								"simple": "INTEGER"
-							}
-						},
-						"description": "short desc"
-					}
-				},
-				"numbers_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "long description will be truncated in table"
-					}
-				},
-				"run_local_at_count": {
-					"var": {
-						"type": {
-							"simple": "INTEGER"
-						},
-						"description": "run_local_at_count"
-					},
-					"default": {
-						"scalar": {
-							"primitive": {
-								"integer": "10"
-							}
-						}
-					}
-				}
-			}
-		},
-		"createdAt": "1970-01-01T00:00:01Z"
-	}
-}`)
+	tearDownAndVerify(t, `{"id": {"name": "launchplan1","version": "v2"},"spec": {"workflowId": {"name": "workflow2"},"defaultInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}}},"closure": {"expectedInputs": {"parameters": {"numbers": {"var": {"type": {"collectionType": {"simple": "INTEGER"}},"description": "short desc"}},"numbers_count": {"var": {"type": {"simple": "INTEGER"},"description": "long description will be truncated in table"}},"run_local_at_count": {"var": {"type": {"simple": "INTEGER"},"description": "run_local_at_count"},"default": {"scalar": {"primitive": {"integer": "10"}}}}}},"createdAt": "1970-01-01T00:00:01Z"}}`)
 }
 
 func TestGetLaunchPlanTableFunc(t *testing.T) {


### PR DESCRIPTION

# TL;DR

```
flytectl get launchplan -d development -p flytesnacks --workflow core.flyte_basics.lp.go_greet 
 --------- ------------------------------- ------------- ----------------------------- 
| VERSION | NAME                          | TYPE        | CREATEDAT                   |
 --------- ------------------------------- ------------- ----------------------------- 
| v15     | morning_greeting              | LAUNCH_PLAN | 2022-03-04T15:42:06.257544Z |
 --------- ------------------------------- ------------- ----------------------------- 
| v15     | core.flyte_basics.lp.go_greet | LAUNCH_PLAN | 2022-03-04T15:42:06.250697Z |
 --------- ------------------------------- ------------- ----------------------------- 
```

## Type
- [ ] Bug Fix
- [X] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [X] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2228

## Follow-up issue
_NA_
