### PR TITLE
fix create project command

### DIFF
--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -56,10 +56,9 @@ func (c *ConfigProject) GetProjectSpec(id string) (*admin.Project, error) {
 		if err != nil {
 			return nil, err
 		}
-		if projectSpec.Id == id {
-			return &projectSpec, nil
+		if len(id) > 0 {
+			projectSpec.Id = id
 		}
-		projectSpec.Id = id
 		return &projectSpec, nil
 	}
 


### PR DESCRIPTION
# TL;DR
- When we create a new project using `flytectl create project --file project.yaml`, I'm required to pass a --id flag, even when the project's id is specified inside the YAML file. It's a bug

```
# Create Project by defining id in file
flytectl create project --file project.yaml

# Override project ID
flytectl create project --file project.yaml --id flytetest
```


## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
