### PR TITLE
Include workflow execution creation as part of flytectl create workflow

### DIFF
--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -131,6 +131,23 @@ Modified file with struct data populated for 'x' and 'y' parameters for the task
 Create execution for a workflow
 ===============================
 
+#. Generate an execution spec file.
+
+   .. prompt:: bash $
+
+      flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
+
+#. Create an execution using the exec spec file.
+
+   .. prompt:: bash $
+
+      flytectl create execution --project flytesnacks --domain development --execFile exec_spec.yaml
+
+#. Monitor the execution by providing the execution name from the ``create execution`` command.
+
+   .. prompt:: bash $
+
+      flytectl get execution --project flytesnacks --domain development <execname>
 
 
 Usage

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -61,12 +61,59 @@ The generated spec file can be modified to change the input values, as shown bel
 	task: core.advanced.run_merge_sort.merge
 	version: "v2"
 
-3. Create an execution by passing the generated YAML file.
+3. Run the execution by passing the generated YAML file.
 The file can then be passed through the command line.
 It is worth noting that the source's and target's project and domain can be different.
 ::
 
 	flytectl create execution --execFile execution_spec.yaml -p flytesnacks -d staging --targetProject flytesnacks
+
+Create execution for a workflow
+===============================
+
+1. Generate an execution spec file.
+::
+
+  flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
+
+The generated file would look similar to the following:
+
+.. code-block:: yaml
+
+  iamRoleARN: ""
+  inputs: {}
+  kubeServiceAcct: ""
+  targetDomain: ""
+  targetProject: ""
+  version: v1
+  workflow: flyte.workflows.example.my_wf
+
+2. [Optional] Update the inputs for the execution, if needed. The generated spec file can be modified to change the input values, as shown below:
+
+.. code-block:: yaml
+
+  iamRoleARN: 'arn:aws:iam::12345678:role/defaultrole'
+  inputs:
+  sorted_list1:
+  - 2
+  - 4
+  - 6
+  sorted_list2:
+  - 1
+  - 3
+  - 5
+  kubeServiceAcct: ""
+  targetDomain: ""
+  targetProject: ""
+  version: "v1"
+  workflow: flyte.workflows.example.my_wf
+
+3. Run the execution using the exec spec file. The file can then be passed through the command line. It is worth noting that the source’s and target’s project and domain can be different.
+::
+
+  flytectl create execution --project flytesnacks --domain development --execFile exec_spec.yaml
+
+The following commands are common to both task and worflow:
 
 To relaunch an execution, pass the current execution ID as follows:
 
@@ -125,70 +172,6 @@ Modified file with struct data populated for 'x' and 'y' parameters for the task
   targetProject: ""
   task: core.type_system.custom_objects.add
   version: v3
-
-Create execution for a workflow
-===============================
-
-1. Generate an execution spec file.
-::
-
-  flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
-
-The generated file would look similar to the following:
-
-.. code-block:: yaml
-
-  iamRoleARN: ""
-  inputs: {}
-  kubeServiceAcct: ""
-  targetDomain: ""
-  targetProject: ""
-  version: v1
-  workflow: flyte.workflows.example.my_wf
-
-2. [Optional] Update the inputs for the execution, if needed. The generated spec file can be modified to change the input values, as shown below:
-
-.. code-block:: yaml
-
-  iamRoleARN: 'arn:aws:iam::12345678:role/defaultrole'
-  inputs:
-  sorted_list1:
-  - 2
-  - 4
-  - 6
-  sorted_list2:
-  - 1
-  - 3
-  - 5
-  kubeServiceAcct: ""
-  targetDomain: ""
-  targetProject: ""
-  version: "v1"
-  workflow: flyte.workflows.example.my_wf
-
-3. Create an execution using the exec spec file. The file can then be passed through the command line. It is worth noting that the source’s and target’s project and domain can be different.
-::
-
-  flytectl create execution --project flytesnacks --domain development --execFile exec_spec.yaml
-
-To relaunch an execution, pass the current execution ID as follows:
-
-::
-
-  flytectl create execution --relaunch <execution name> --project flytesnacks --domain development
-
-To recover an execution, i.e., recreate it from the last known failure point for previously-run workflow execution, run:
-
-::
-
-  flytectl create execution --recover <execution name> -p flytesnacks -d development
-
-4. Monitor the execution by providing the execution name from the ``create execution`` command.
-
-::
-
-  flytectl get execution --project flytesnacks --domain development <execution name>
-
 
 Usage
 

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -65,14 +65,15 @@ Create execution for a workflow
 ===============================
 
 1. Generate an execution spec file.
+::
 
-   .. prompt:: bash $
-
-      flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
+  flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
 
 The generated file looks similar to the above mentioned task file.
 
+
 The following steps are common to both a task and workflow:
+
 
 Create an execution by passing the generated YAML file.
 The file can then be passed through the command line.

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -10,14 +10,14 @@ Synopsis
 
 
 
-Create execution resources for a given workflow or task in a project and domain.
+Create execution resources for a given workflow or task in a project and domain. 
 
+
+There are three steps to generate an execution, as outlined below:
 
 
 Create execution for a task
 ===========================
-
-There are three steps to generate an execution, as outlined below:
 
 1. Generate the execution spec file using the :ref:`get task <flytectl_get_task>` command.
 ::

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -12,6 +12,11 @@ Synopsis
 
 Create execution resources for a given workflow or task in a project and domain.
 
+
+
+Create execution for a task
+===========================
+
 There are three steps to generate an execution, as outlined below:
 
 1. Generate the execution spec file using the :ref:`get task <flytectl_get_task>` command.
@@ -120,6 +125,13 @@ Modified file with struct data populated for 'x' and 'y' parameters for the task
   targetProject: ""
   task: core.type_system.custom_objects.add
   version: v3
+
+
+
+Create execution for a workflow
+===============================
+
+
 
 Usage
 

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -61,21 +61,7 @@ The generated spec file can be modified to change the input values, as shown bel
 	task: core.advanced.run_merge_sort.merge
 	version: "v2"
 
-Create execution for a workflow
-===============================
-
-1. Generate an execution spec file.
-::
-
-  flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
-
-The generated file looks similar to the above mentioned task file.
-
-
-The following steps are common to both a task and workflow:
-
-
-Create an execution by passing the generated YAML file.
+3. Create an execution by passing the generated YAML file.
 The file can then be passed through the command line.
 It is worth noting that the source's and target's project and domain can be different.
 ::
@@ -139,6 +125,70 @@ Modified file with struct data populated for 'x' and 'y' parameters for the task
   targetProject: ""
   task: core.type_system.custom_objects.add
   version: v3
+
+Create execution for a workflow
+===============================
+
+1. Generate an execution spec file.
+::
+
+  flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
+
+The generated file would look similar to the following:
+
+.. code-block:: yaml
+
+  iamRoleARN: ""
+  inputs: {}
+  kubeServiceAcct: ""
+  targetDomain: ""
+  targetProject: ""
+  version: v1
+  workflow: flyte.workflows.example.my_wf
+
+2. [Optional] Update the inputs for the execution, if needed. The generated spec file can be modified to change the input values, as shown below:
+
+.. code-block:: yaml
+
+  iamRoleARN: 'arn:aws:iam::12345678:role/defaultrole'
+  inputs:
+  sorted_list1:
+  - 2
+  - 4
+  - 6
+  sorted_list2:
+  - 1
+  - 3
+  - 5
+  kubeServiceAcct: ""
+  targetDomain: ""
+  targetProject: ""
+  version: "v1"
+  workflow: flyte.workflows.example.my_wf
+
+3. Create an execution using the exec spec file. The file can then be passed through the command line. It is worth noting that the source’s and target’s project and domain can be different.
+::
+
+  flytectl create execution --project flytesnacks --domain development --execFile exec_spec.yaml
+
+To relaunch an execution, pass the current execution ID as follows:
+
+::
+
+  flytectl create execution --relaunch <execution name> --project flytesnacks --domain development
+
+To recover an execution, i.e., recreate it from the last known failure point for previously-run workflow execution, run:
+
+::
+
+  flytectl create execution --recover <execution name> -p flytesnacks -d development
+
+4. Monitor the execution by providing the execution name from the ``create execution`` command.
+
+::
+
+  flytectl get execution --project flytesnacks --domain development <execution name>
+
 
 Usage
 

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -61,7 +61,20 @@ The generated spec file can be modified to change the input values, as shown bel
 	task: core.advanced.run_merge_sort.merge
 	version: "v2"
 
-3. Run the execution by passing the generated YAML file.
+Create execution for a workflow
+===============================
+
+1. Generate an execution spec file.
+
+   .. prompt:: bash $
+
+      flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
+
+The generated file looks similar to the above mentioned task file.
+
+The following steps are common to both a task and workflow:
+
+Create an execution by passing the generated YAML file.
 The file can then be passed through the command line.
 It is worth noting that the source's and target's project and domain can be different.
 ::
@@ -126,32 +139,7 @@ Modified file with struct data populated for 'x' and 'y' parameters for the task
   task: core.type_system.custom_objects.add
   version: v3
 
-
-
-Create execution for a workflow
-===============================
-
-#. Generate an execution spec file.
-
-   .. prompt:: bash $
-
-      flytectl get launchplan --project flytesnacks --domain development flyte.workflows.example.my_wf --latest --execFile exec_spec.yaml
-
-#. Create an execution using the exec spec file.
-
-   .. prompt:: bash $
-
-      flytectl create execution --project flytesnacks --domain development --execFile exec_spec.yaml
-
-#. Monitor the execution by providing the execution name from the ``create execution`` command.
-
-   .. prompt:: bash $
-
-      flytectl get execution --project flytesnacks --domain development <execname>
-
-
 Usage
-
 
 ::
 


### PR DESCRIPTION
Signed-off-by: Alekhya Sai Punnamaraju <alekhyasaip@gmail.com>

# TL;DR
Currently, the documentation page includes task execution creation and not workflow execution creation. This PR adds the workflow execution creation.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
N/A

## Tracking Issue
Fixes: https://github.com/flyteorg/flyte/issues/2201
