### PR TITLE
fix: revert sandbox lite image tag prefix to sha

### DIFF
--- a/boilerplate/flyte/golang_support_tools/tools.go
+++ b/boilerplate/flyte/golang_support_tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools
@@ -6,6 +7,6 @@ import (
 	_ "github.com/alvaroloes/enumer"
 	_ "github.com/flyteorg/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/vektra/mockery/cmd/mockery"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+	_ "github.com/vektra/mockery/cmd/mockery"
 )

--- a/cmd/demo/start.go
+++ b/cmd/demo/start.go
@@ -58,12 +58,24 @@ Specify a Flyte demo image pull policy. Possible pull policy values are Always, 
 
  flytectl demo start  --image docker.io/my-override:latest --imagePullPolicy Always
 
+Runs a specific version of Flyte. Flytectl sandbox only supports Flyte version available in the Github release, https://github.com/flyteorg/flyte/tags.
+::
+
+ flytectl sandbox start  --version=v0.14.0
+
+.. note::
+	  Flytectl Sandbox is only supported for Flyte versions > v1.0.0
+
+Runs the latest pre release of  Flyte.
+::
+
+ flytectl sandbox start  --pre
+
 Start demo cluster passing environment variables. This can be used to pass docker specific env variables or flyte specific env variables.
 eg : for passing timeout value in secs for the demo container use the following.
 ::
 
  flytectl demo start --env FLYTE_TIMEOUT=700
-
 
 The DURATION can be a positive integer or a floating-point number, followed by an optional unit suffix::
 s - seconds (default)

--- a/cmd/demo/start.go
+++ b/cmd/demo/start.go
@@ -56,20 +56,20 @@ Note: If image flag is passed then Flytectl will ignore version and pre flags.
 Specify a Flyte demo image pull policy. Possible pull policy values are Always, IfNotPresent, or Never:
 ::
 
- flytectl demo start  --image docker.io/my-override:latest --imagePullPolicy Always
+ flytectl demo start --image docker.io/my-override:latest --imagePullPolicy Always
 
-Runs a specific version of Flyte. Flytectl sandbox only supports Flyte version available in the Github release, https://github.com/flyteorg/flyte/tags.
+Runs a specific version of Flyte. Flytectl demo only supports Flyte version available in the Github release, https://github.com/flyteorg/flyte/tags.
 ::
 
- flytectl sandbox start  --version=v0.14.0
+ flytectl demo start --version=v0.14.0
 
 .. note::
-	  Flytectl Sandbox is only supported for Flyte versions > v1.0.0
+	  Flytectl demo is only supported for Flyte versions >= v1.0.0
 
 Runs the latest pre release of  Flyte.
 ::
 
- flytectl sandbox start  --pre
+ flytectl demo start --pre
 
 Start demo cluster passing environment variables. This can be used to pass docker specific env variables or flyte specific env variables.
 eg : for passing timeout value in secs for the demo container use the following.

--- a/cmd/demo/start.go
+++ b/cmd/demo/start.go
@@ -40,11 +40,11 @@ Starts the demo cluster without any source code:
 ::
 
  flytectl demo start
-	
+
 Mounts your source code repository inside the demo cluster:
 ::
 
- flytectl demo start --source=$HOME/flyteorg/flytesnacks 
+ flytectl demo start --source=$HOME/flyteorg/flytesnacks
 
 Specify a Flyte demo compliant image with the registry. This is useful in case you want to use an image from your registry.
 ::
@@ -52,7 +52,7 @@ Specify a Flyte demo compliant image with the registry. This is useful in case y
   flytectl demo start --image docker.io/my-override:latest
 
 Note: If image flag is passed then Flytectl will ignore version and pre flags.
-	
+
 Specify a Flyte demo image pull policy. Possible pull policy values are Always, IfNotPresent, or Never:
 ::
 
@@ -199,7 +199,7 @@ func startDemo(ctx context.Context, cli docker.Docker, reader io.Reader) (*bufio
 	}
 	demoImage := sandboxConfig.DefaultConfig.Image
 	if len(demoImage) == 0 {
-		image, version, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, demoImageName, sandboxConfig.DefaultConfig.Prerelease)
+		image, version, err := githubutil.GetFullyQualifiedImageName("sha", sandboxConfig.DefaultConfig.Version, demoImageName, sandboxConfig.DefaultConfig.Prerelease)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/demo/start_test.go
+++ b/cmd/demo/start_test.go
@@ -91,7 +91,7 @@ func TestStartDemoFunc(t *testing.T) {
 		errCh := make(chan error)
 		sandboxConfig.DefaultConfig.Version = "v0.19.1"
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", sandboxConfig.DefaultConfig.Version, demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -122,7 +122,7 @@ func TestStartDemoFunc(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -171,7 +171,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -213,7 +213,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: absPath,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -248,7 +248,7 @@ func TestStartDemoFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = "v0.18.0"
 		sandboxConfig.DefaultConfig.Source = ""
 
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", sandboxConfig.DefaultConfig.Version, demoImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -283,7 +283,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Version = "v0.1444.0"
 		sandboxConfig.DefaultConfig.Source = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -316,7 +316,7 @@ func TestStartDemoFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
 		volumes := docker.Volumes
@@ -362,7 +362,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -404,7 +404,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = ""
 		sandboxConfig.DefaultConfig.Version = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -443,7 +443,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -483,7 +483,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -527,7 +527,7 @@ func TestStartDemoFunc(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -570,7 +570,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -705,26 +705,26 @@ func TestGetNodeTaintStatus(t *testing.T) {
 
 func TestGetDemoImage(t *testing.T) {
 	t.Run("Get Latest demo cluster", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "", demoImageName, false)
 		assert.Nil(t, err)
-		assert.Equal(t, true, strings.HasPrefix(image, "cr.flyte.org/flyteorg/flyte-sandbox-lite:dind-"))
+		assert.Equal(t, true, strings.HasPrefix(image, "cr.flyte.org/flyteorg/flyte-sandbox-lite:sha-"))
 	})
 
 	t.Run("Get demo image with version ", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.14.0", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("sha", "v0.14.0", demoImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(image, demoImageName))
 	})
 	t.Run("Get demo image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v100.1.0", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("sha", "v100.1.0", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get demo image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "aaaaaa", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("sha", "aaaaaa", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get demo image with version that is not supported", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.10.0", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("sha", "v0.10.0", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 

--- a/cmd/demo/start_test.go
+++ b/cmd/demo/start_test.go
@@ -91,7 +91,7 @@ func TestStartDemoFunc(t *testing.T) {
 		errCh := make(chan error)
 		sandboxConfig.DefaultConfig.Version = "v0.19.1"
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -122,7 +122,7 @@ func TestStartDemoFunc(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -171,7 +171,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -213,7 +213,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: absPath,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -248,7 +248,7 @@ func TestStartDemoFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = "v0.18.0"
 		sandboxConfig.DefaultConfig.Source = ""
 
-		image, _, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, demoImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -283,7 +283,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Version = "v0.1444.0"
 		sandboxConfig.DefaultConfig.Source = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -316,7 +316,7 @@ func TestStartDemoFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
 		volumes := docker.Volumes
@@ -362,7 +362,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -404,7 +404,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = ""
 		sandboxConfig.DefaultConfig.Version = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -443,7 +443,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -483,7 +483,7 @@ func TestStartDemoFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -527,7 +527,7 @@ func TestStartDemoFunc(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -570,7 +570,7 @@ func TestStartDemoFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -705,26 +705,26 @@ func TestGetNodeTaintStatus(t *testing.T) {
 
 func TestGetDemoImage(t *testing.T) {
 	t.Run("Get Latest demo cluster", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", demoImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(image, "cr.flyte.org/flyteorg/flyte-sandbox-lite:dind-"))
 	})
 
 	t.Run("Get demo image with version ", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("v0.14.0", demoImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.14.0", demoImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(image, demoImageName))
 	})
 	t.Run("Get demo image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("v100.1.0", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v100.1.0", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get demo image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("aaaaaa", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "aaaaaa", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get demo image with version that is not supported", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("v0.10.0", demoImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.10.0", demoImageName, false)
 		assert.NotNil(t, err)
 	})
 

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -40,12 +40,12 @@ Starts the sandbox cluster without any source code:
 ::
 
  flytectl sandbox start
-	
+
 Mounts your source code repository inside the sandbox:
 ::
 
- flytectl sandbox start --source=$HOME/flyteorg/flytesnacks 
-	
+ flytectl sandbox start --source=$HOME/flyteorg/flytesnacks
+
 Runs a specific version of Flyte. Flytectl sandbox only supports Flyte version available in the Github release, https://github.com/flyteorg/flyte/tags.
 ::
 
@@ -59,7 +59,7 @@ Runs the latest pre release of  Flyte.
 
  flytectl sandbox start  --pre
 
-Note: The pre release flag will be ignored if the user passes the version flag. In that case, Flytectl will use a specific version. 
+Note: The pre release flag will be ignored if the user passes the version flag. In that case, Flytectl will use a specific version.
 
 Specify a Flyte Sandbox compliant image with the registry. This is useful in case you want to use an image from your registry.
 ::
@@ -67,7 +67,7 @@ Specify a Flyte Sandbox compliant image with the registry. This is useful in cas
   flytectl sandbox start --image docker.io/my-override:latest
 
 Note: If image flag is passed then Flytectl will ignore version and pre flags.
-	
+
 Specify a Flyte Sandbox image pull policy. Possible pull policy values are Always, IfNotPresent, or Never:
 ::
 
@@ -191,7 +191,7 @@ func startSandbox(ctx context.Context, cli docker.Docker, reader io.Reader) (*bu
 	}
 	sandboxImage := sandboxConfig.DefaultConfig.Image
 	if len(sandboxImage) == 0 {
-		image, version, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, sandboxImageName, sandboxConfig.DefaultConfig.Prerelease)
+		image, version, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, sandboxImageName, sandboxConfig.DefaultConfig.Prerelease)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/sandbox/start_test.go
+++ b/cmd/sandbox/start_test.go
@@ -92,7 +92,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		sandboxConfig.DefaultConfig.Version = "v0.19.1"
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -123,7 +123,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		ctx := context.Background()
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -172,7 +172,7 @@ func TestStartSandboxFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -214,7 +214,7 @@ func TestStartSandboxFunc(t *testing.T) {
 			Source: absPath,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -249,7 +249,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		sandboxConfig.DefaultConfig.Version = "v0.18.0"
 		sandboxConfig.DefaultConfig.Source = ""
 
-		image, _, err := githubutil.GetFullyQualifiedImageName(sandboxConfig.DefaultConfig.Version, sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", sandboxConfig.DefaultConfig.Version, sandboxImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -284,7 +284,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Version = "v0.1444.0"
 		sandboxConfig.DefaultConfig.Source = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		volumes := docker.Volumes
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -317,7 +317,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker := &mocks.Docker{}
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		sandboxConfig.DefaultConfig.Source = f.UserHomeDir()
 		volumes := docker.Volumes
@@ -363,7 +363,7 @@ func TestStartSandboxFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -405,7 +405,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		sandboxConfig.DefaultConfig.Source = ""
 		sandboxConfig.DefaultConfig.Version = ""
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -444,7 +444,7 @@ func TestStartSandboxFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -484,7 +484,7 @@ func TestStartSandboxFunc(t *testing.T) {
 			Source: sandboxConfig.DefaultConfig.Source,
 			Target: docker.Source,
 		})
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -528,7 +528,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
@@ -571,7 +571,7 @@ func TestStartSandboxFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		errCh := make(chan error)
 		bodyStatus := make(chan container.ContainerWaitOKBody)
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		mockDocker.OnContainerCreate(ctx, &container.Config{
 			Env:          docker.Environment,
@@ -706,26 +706,26 @@ func TestGetNodeTaintStatus(t *testing.T) {
 
 func TestGetSandboxImage(t *testing.T) {
 	t.Run("Get Latest sandbox", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(image, "cr.flyte.org/flyteorg/flyte-sandbox:dind-"))
 	})
 
 	t.Run("Get sandbox image with version ", func(t *testing.T) {
-		image, _, err := githubutil.GetFullyQualifiedImageName("v0.14.0", sandboxImageName, false)
+		image, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.14.0", sandboxImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(image, sandboxImageName))
 	})
 	t.Run("Get sandbox image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("v100.1.0", sandboxImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v100.1.0", sandboxImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get sandbox image with wrong version ", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("aaaaaa", sandboxImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "aaaaaa", sandboxImageName, false)
 		assert.NotNil(t, err)
 	})
 	t.Run("Get sandbox image with version that is not supported", func(t *testing.T) {
-		_, _, err := githubutil.GetFullyQualifiedImageName("v0.10.0", sandboxImageName, false)
+		_, _, err := githubutil.GetFullyQualifiedImageName("dind", "v0.10.0", sandboxImageName, false)
 		assert.NotNil(t, err)
 	})
 

--- a/pkg/githubutil/githubutil.go
+++ b/pkg/githubutil/githubutil.go
@@ -218,11 +218,11 @@ func CheckBrewInstall(goos platformutil.Platform) (string, error) {
 // if no version is specified then the Latest release of cr.flyte.org/flyteorg/flyte-sandbox:dind-{SHA} is used
 // else cr.flyte.org/flyteorg/flyte-sandbox:dind-{SHA}, where sha is derived from the version.
 // If pre release is true then use latest pre release of Flyte, In that case User don't need to pass version
-func GetFullyQualifiedImageName(version, image string, pre bool) (string, string, error) {
+func GetFullyQualifiedImageName(prefix, version, image string, pre bool) (string, string, error) {
 	sha, version, err := GetSandboxImageSha(version, pre)
 	if err != nil {
 		return "", version, err
 	}
 
-	return fmt.Sprintf("%s:%s", image, fmt.Sprintf("dind-%s", sha)), version, nil
+	return fmt.Sprintf("%s:%s", image, fmt.Sprintf("%s-%s", prefix, sha)), version, nil
 }

--- a/pkg/githubutil/githubutil_test.go
+++ b/pkg/githubutil/githubutil_test.go
@@ -49,19 +49,19 @@ func TestCheckVersionExist(t *testing.T) {
 
 func TestGetFullyQualifiedImageName(t *testing.T) {
 	t.Run("Get tFully Qualified Image Name ", func(t *testing.T) {
-		image, tag, err := GetFullyQualifiedImageName("", sandboxImageName, false)
+		image, tag, err := GetFullyQualifiedImageName("dind", "", sandboxImageName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(tag, "v"))
 		assert.Equal(t, true, strings.HasPrefix(image, sandboxImageName))
 	})
 	t.Run("Get tFully Qualified Image Name with pre release", func(t *testing.T) {
-		image, tag, err := GetFullyQualifiedImageName("", sandboxImageName, true)
+		image, tag, err := GetFullyQualifiedImageName("dind", "", sandboxImageName, true)
 		assert.Nil(t, err)
 		assert.Equal(t, true, strings.HasPrefix(tag, "v"))
 		assert.Equal(t, true, strings.HasPrefix(image, sandboxImageName))
 	})
 	t.Run("Get tFully Qualified Image Name with specific version", func(t *testing.T) {
-		image, tag, err := GetFullyQualifiedImageName("v0.19.0", sandboxImageName, true)
+		image, tag, err := GetFullyQualifiedImageName("dind", "v0.19.0", sandboxImageName, true)
 		assert.Nil(t, err)
 		assert.Equal(t, "v0.19.0", tag)
 		assert.Equal(t, true, strings.HasPrefix(image, sandboxImageName))


### PR DESCRIPTION
# TL;DR
Currently we are not publishing sandbox lite image with `dind` tag prefix, reverted sandbox lite image prefix tag to `sha`

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
