### PR TITLE
Bind 30080 to 30081 in the case of sandbox

### DIFF
--- a/cmd/demo/start.go
+++ b/cmd/demo/start.go
@@ -224,7 +224,7 @@ func startDemo(ctx context.Context, cli docker.Docker, reader io.Reader) (*bufio
 	}
 
 	fmt.Printf("%v booting flyte-demo container\n", emoji.FactoryWorker)
-	exposedPorts, portBindings, _ := docker.GetSandboxPorts()
+	exposedPorts, portBindings, _ := docker.GetDemoPorts()
 	ID, err := docker.StartContainer(ctx, cli, volumes, exposedPorts, portBindings, docker.FlyteSandboxClusterName,
 		demoImage, sandboxDefaultConfig.Env)
 

--- a/cmd/demo/start_test.go
+++ b/cmd/demo/start_test.go
@@ -78,7 +78,7 @@ var fakePod = corev1.Pod{
 }
 
 func TestStartDemoFunc(t *testing.T) {
-	p1, p2, _ := docker.GetSandboxPorts()
+	p1, p2, _ := docker.GetDemoPorts()
 	assert.Nil(t, util.SetupFlyteDir())
 	assert.Nil(t, os.MkdirAll(f.FilePathJoin(f.UserHomeDir(), ".flyte", "k3s"), os.ModePerm))
 	assert.Nil(t, ioutil.WriteFile(docker.Kubeconfig, []byte(content), os.ModePerm))

--- a/pkg/docker/docker_util.go
+++ b/pkg/docker/docker_util.go
@@ -94,6 +94,21 @@ func RemoveSandbox(ctx context.Context, cli Docker, reader io.Reader) error {
 // GetSandboxPorts will return sandbox ports
 func GetSandboxPorts() (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
 	return nat.ParsePortSpecs([]string{
+		// Notice that two host ports are mapped to the same container port in the case of Flyteconsole, this is done to
+		// support the generated URLs produced by pyflyte run
+		"0.0.0.0:30080:30081", // Flyteconsole Port.
+		"0.0.0.0:30081:30081", // Flyteadmin Port
+		"0.0.0.0:30082:30082", // K8s Dashboard Port
+		"0.0.0.0:30084:30084", // Minio API Port
+		"0.0.0.0:30086:30086", // K8s cluster
+		"0.0.0.0:30088:30088", // Minio Console Port
+		"0.0.0.0:30089:30089", // Postgres Port
+	})
+}
+
+// GetDemoPorts will return demo ports
+func GetDemoPorts() (map[nat.Port]struct{}, map[nat.Port][]nat.PortBinding, error) {
+	return nat.ParsePortSpecs([]string{
 		"0.0.0.0:30080:30080", // Flyteconsole Port
 		"0.0.0.0:30081:30081", // Flyteadmin Port
 		"0.0.0.0:30082:30082", // K8s Dashboard Port


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
Expose port 30080 as flyteconsole in the sandbox

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
`pyflyte run` produces a url to help users follow the progress of their executions, but right now it hardcodes the port to 30080 in the case of localhost. This was done because that's the port used in single binary. 

This PR binds 2 host ports to 30081 in the case of sandbox. This causes a minor inconvenience in that now console can be reached via two ports, but we think this is a reasonable trade-off vis-a-vis the failure to expose the service http endpoint added in https://github.com/flyteorg/flyteidl/pull/277/.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
