### PR TITLE
flyetcl version should ignore talking to admin if host is not configures

### DIFF
--- a/cmd/core/cmd.go
+++ b/cmd/core/cmd.go
@@ -61,6 +61,10 @@ func generateCommandFunc(cmdEntry CommandEntry) func(cmd *cobra.Command, args []
 		}
 
 		adminCfg := admin.GetConfig(ctx)
+		if len(adminCfg.Endpoint.String()) == 0 {
+			return cmdEntry.CmdFunc(ctx, args, CommandContext{})
+		}
+
 		clientSet, err := admin.ClientSetBuilder().WithConfig(admin.GetConfig(ctx)).
 			WithTokenCache(pkce.TokenCacheKeyringProvider{
 				ServiceUser: fmt.Sprintf("%s:%s", adminCfg.Endpoint.String(), pkce.KeyRingServiceUser),

--- a/cmd/core/cmd_test.go
+++ b/cmd/core/cmd_test.go
@@ -17,11 +17,22 @@ func testCommandFunc(ctx context.Context, args []string, cmdCtx CommandContext) 
 }
 
 func TestGenerateCommandFunc(t *testing.T) {
-	adminCfg := admin.GetConfig(context.Background())
-	adminCfg.Endpoint = config.URL{URL: url.URL{Host: "dummyHost"}}
-	adminCfg.AuthType = admin.AuthTypePkce
-	rootCmd := &cobra.Command{}
-	cmdEntry := CommandEntry{CmdFunc: testCommandFunc, ProjectDomainNotRequired: true}
-	fn := generateCommandFunc(cmdEntry)
-	assert.Nil(t, fn(rootCmd, []string{}))
+	t.Run("dummy host name", func(t *testing.T) {
+		adminCfg := admin.GetConfig(context.Background())
+		adminCfg.Endpoint = config.URL{URL: url.URL{Host: "dummyHost"}}
+		adminCfg.AuthType = admin.AuthTypePkce
+		rootCmd := &cobra.Command{}
+		cmdEntry := CommandEntry{CmdFunc: testCommandFunc, ProjectDomainNotRequired: true}
+		fn := generateCommandFunc(cmdEntry)
+		assert.Nil(t, fn(rootCmd, []string{}))
+	})
+
+	t.Run("host is not configured", func(t *testing.T) {
+		adminCfg := admin.GetConfig(context.Background())
+		adminCfg.Endpoint = config.URL{URL: url.URL{Host: ""}}
+		rootCmd := &cobra.Command{}
+		cmdEntry := CommandEntry{CmdFunc: testCommandFunc, ProjectDomainNotRequired: true}
+		fn := generateCommandFunc(cmdEntry)
+		assert.Nil(t, fn(rootCmd, []string{}))
+	})
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"runtime"
 
+	adminClient "github.com/flyteorg/flyteidl/clients/go/admin"
+
 	"github.com/flyteorg/flytectl/pkg/github"
 
 	"github.com/flyteorg/flytectl/pkg/platformutil"
@@ -75,6 +77,11 @@ func getVersion(ctx context.Context, args []string, cmdCtx cmdCore.CommandContex
 	}); err != nil {
 		return err
 	}
+
+	if len(adminClient.GetConfig(ctx).Endpoint.String()) == 0 {
+		return nil
+	}
+
 	// Print Flyteadmin version if available
 	if err := getControlPlaneVersion(ctx, cmdCtx); err != nil {
 		logger.Debug(ctx, err)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"runtime"
 
-	adminClient "github.com/flyteorg/flyteidl/clients/go/admin"
-
 	"github.com/flyteorg/flytectl/pkg/github"
 
 	"github.com/flyteorg/flytectl/pkg/platformutil"
@@ -78,10 +76,6 @@ func getVersion(ctx context.Context, args []string, cmdCtx cmdCore.CommandContex
 		return err
 	}
 
-	if len(adminClient.GetConfig(ctx).Endpoint.String()) == 0 {
-		return nil
-	}
-
 	// Print Flyteadmin version if available
 	if err := getControlPlaneVersion(ctx, cmdCtx); err != nil {
 		logger.Debug(ctx, err)
@@ -99,6 +93,11 @@ func printVersion(response versionOutput) error {
 }
 
 func getControlPlaneVersion(ctx context.Context, cmdCtx cmdCore.CommandContext) error {
+	if cmdCtx.ClientSet() == nil {
+		logger.Debug(ctx, "Ignore talking to admin if host is not configured")
+		return nil
+	}
+
 	v, err := cmdCtx.AdminClient().GetVersion(ctx, &admin.GetVersionRequest{})
 	if err != nil || v == nil {
 		logger.Debugf(ctx, "Failed to get version of control plane %v: \n", err)

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -64,7 +64,7 @@ func TestVersionCommandFunc(t *testing.T) {
 	s.MockClient.AdminClient().(*mocks.AdminServiceClient).OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, nil)
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertNotCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionCommandFuncError(t *testing.T) {

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -64,7 +64,7 @@ func TestVersionCommandFunc(t *testing.T) {
 	s.MockClient.AdminClient().(*mocks.AdminServiceClient).OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, nil)
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertNotCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionCommandFuncError(t *testing.T) {
@@ -76,7 +76,7 @@ func TestVersionCommandFuncError(t *testing.T) {
 	s.MockClient.AdminClient().(*mocks.AdminServiceClient).OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, nil)
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertNotCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionCommandFuncErr(t *testing.T) {
@@ -88,7 +88,7 @@ func TestVersionCommandFuncErr(t *testing.T) {
 	s.MockAdminClient.OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, errors.New("error"))
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockAdminClient.AssertNotCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockAdminClient.AssertCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionUtilFunc(t *testing.T) {

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -76,7 +76,7 @@ func TestVersionCommandFuncError(t *testing.T) {
 	s.MockClient.AdminClient().(*mocks.AdminServiceClient).OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, nil)
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockClient.AdminClient().(*mocks.AdminServiceClient).AssertNotCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionCommandFuncErr(t *testing.T) {
@@ -88,7 +88,7 @@ func TestVersionCommandFuncErr(t *testing.T) {
 	s.MockAdminClient.OnGetVersionMatch(ctx, versionRequest).Return(versionResponse, errors.New("error"))
 	err := getVersion(s.Ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)
-	s.MockAdminClient.AssertCalled(t, "GetVersion", ctx, versionRequest)
+	s.MockAdminClient.AssertNotCalled(t, "GetVersion", ctx, versionRequest)
 }
 
 func TestVersionUtilFunc(t *testing.T) {

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -115,5 +115,10 @@ func TestVersionUtilFunc(t *testing.T) {
 		err := getVersion(ctx, []string{}, cmdCtx)
 		assert.Nil(t, err)
 	})
-
+	t.Run("ClientSet is empty", func(t *testing.T) {
+		ctx := context.Background()
+		cmdCtx := cmdCore.CommandContext{}
+		err := getVersion(ctx, []string{}, cmdCtx)
+		assert.Nil(t, err)
+	})
 }

--- a/pkg/github/githubutil.go
+++ b/pkg/github/githubutil.go
@@ -168,8 +168,10 @@ func GetUpgradeMessage(latest string, goos platformutil.Platform) (string, error
 	if err != nil {
 		return "", err
 	}
-	message := fmt.Sprintf(commonMessage, stdlibversion.Version, latest)
+
+	var message string
 	if isGreater {
+		message = fmt.Sprintf(commonMessage, stdlibversion.Version, latest)
 		symlink, err := CheckBrewInstall(goos)
 		if err != nil {
 			return "", err

--- a/pkg/github/githubutil_test.go
+++ b/pkg/github/githubutil_test.go
@@ -183,10 +183,10 @@ func TestGetUpgradeMessage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 157, len(message))
 
-	version = "v0.2.09"
+	version = "v0.2.10"
 	message, err = GetUpgradeMessage(version, darwin)
 	assert.Nil(t, err)
-	assert.Equal(t, 63, len(message))
+	assert.Equal(t, 0, len(message))
 
 	version = "v"
 	message, err = GetUpgradeMessage(version, darwin)

--- a/pkg/github/githubutil_test.go
+++ b/pkg/github/githubutil_test.go
@@ -183,7 +183,7 @@ func TestGetUpgradeMessage(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 157, len(message))
 
-	version = "v0.2.10"
+	version = "v0.2.09"
 	message, err = GetUpgradeMessage(version, darwin)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(message))


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
- Ignore talking to the admin if the host is not configured
- Do not prompt users to install new flytectl if the current version is the same as the latest version
```
 A new release of flytectl is available: v0.5.21 → v0.5.21 

{
  "App": "flytectl",
  "Build": "fc7b1dd",
  "Version": "v0.5.21",
  "BuildTime": "2022-04-27 16:25:14.783715 +0800 CST m=+0.018003092"

```

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2256

## Follow-up issue
_NA_
