### PR TITLE
Fetching unique versions of launchplan using namedentity call

### DIFF
--- a/cmd/config/subcommand/launchplan/launchplan_config.go
+++ b/cmd/config/subcommand/launchplan/launchplan_config.go
@@ -6,8 +6,12 @@ import (
 
 //go:generate pflags Config --default-var DefaultConfig --bind-default-var
 var (
+	lpDefaultFilter = filters.Filters{
+		Limit: filters.DefaultLimit,
+		Page:  1,
+	}
 	DefaultConfig = &Config{
-		Filter: filters.DefaultFilter,
+		Filter: lpDefaultFilter,
 	}
 )
 

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -121,14 +121,6 @@ var launchplanColumns = []printer.Column{
 	{Header: "Outputs", JSONPath: "$.closure.expectedOutputs.variables." + printer.DefaultFormattedDescriptionsKey + ".description"},
 }
 
-// Column structure for get all launchplans
-var launchplansColumns = []printer.Column{
-	{Header: "Version", JSONPath: "$.id.version"},
-	{Header: "Name", JSONPath: "$.id.name"},
-	{Header: "Type", JSONPath: "$.id.resourceType"},
-	{Header: "CreatedAt", JSONPath: "$.closure.createdAt"},
-}
-
 func LaunchplanToProtoMessages(l []*admin.LaunchPlan) []proto.Message {
 	messages := make([]proto.Message, 0, len(l))
 	for _, m := range l {
@@ -186,18 +178,18 @@ func getLaunchPlanFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 		launchplan.DefaultConfig.Filter.FieldSelector = fmt.Sprintf("workflow.name=%s", launchplan.DefaultConfig.Workflow)
 	}
 
-	launchPlans, err := cmdCtx.AdminFetcherExt().FetchAllVerOfLP(ctx, "", config.GetConfig().Project, config.GetConfig().Domain, launchplan.DefaultConfig.Filter)
+	nameEntities, err := cmdCtx.AdminFetcherExt().FetchAllLPs(ctx, config.GetConfig().Project, config.GetConfig().Domain, launchplan.DefaultConfig.Filter)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf(ctx, "Retrieved %v launch plans", len(launchPlans))
+	logger.Debugf(ctx, "Retrieved %v launch plans", len(nameEntities))
 	if config.GetConfig().MustOutputFormat() == printer.OutputFormatTABLE {
-		return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplansColumns,
-			LaunchplanToTableProtoMessages(launchPlans)...)
+		return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), namedEntityColumns,
+			NamedEntityToProtoMessages(nameEntities)...)
 	}
-	return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), launchplansColumns,
-		LaunchplanToProtoMessages(launchPlans)...)
+	return launchPlanPrinter.Print(config.GetConfig().MustOutputFormat(), namedEntityColumns,
+		NamedEntityToProtoMessages(nameEntities)...)
 
 }
 

--- a/cmd/get/launch_plan_test.go
+++ b/cmd/get/launch_plan_test.go
@@ -232,9 +232,6 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 		s := setup()
 		getLaunchPlanSetup()
 		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "launchplan1", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
-		s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceGetRequest).Return(nil, fmt.Errorf("error fetching all version"))
-		s.MockAdminClient.OnGetLaunchPlanMatch(s.Ctx, objectGetRequest).Return(nil, fmt.Errorf("error fetching lanuch plan"))
-		s.MockAdminClient.OnListLaunchPlanIdsMatch(s.Ctx, namedIDRequest).Return(nil, fmt.Errorf("error listing lanuch plan ids"))
 		err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
 		assert.NotNil(t, err)
 	})
@@ -243,8 +240,7 @@ func TestGetLaunchPlanFuncWithError(t *testing.T) {
 		s := setup()
 		getLaunchPlanSetup()
 		argsLp = []string{}
-		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
-		s.MockAdminClient.OnListLaunchPlansMatch(s.Ctx, resourceListRequest).Return(nil, fmt.Errorf("error fetching all version"))
+		s.FetcherExt.OnFetchAllLPsMatch(s.Ctx, "dummyProject", "dummyDomain", filters.Filters{}).Return(nil, fmt.Errorf("error fetching all version"))
 		err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
 		assert.NotNil(t, err)
 	})
@@ -287,7 +283,8 @@ func TestGetLaunchPlans(t *testing.T) {
 	t.Run("no workflow filter", func(t *testing.T) {
 		s := setup()
 		getLaunchPlanSetup()
-		s.FetcherExt.OnFetchAllVerOfLP(s.Ctx, "", "dummyProject", "dummyDomain", filters.Filters{}).Return(launchPlanListResponse.LaunchPlans, nil)
+		var namedEntityList []*admin.NamedEntity
+		s.FetcherExt.OnFetchAllLPsMatch(s.Ctx, "dummyProject", "dummyDomain", filters.Filters{}).Return(namedEntityList, nil)
 		argsLp = []string{}
 		err := getLaunchPlanFunc(s.Ctx, argsLp, s.CmdCtx)
 		assert.Nil(t, err)

--- a/cmd/testutils/test_utils.go
+++ b/cmd/testutils/test_utils.go
@@ -99,9 +99,11 @@ func SetupWithExt() (s TestStruct) {
 // TearDownAndVerify TODO: Change this to verify log lines from context
 func TearDownAndVerify(t *testing.T, reader io.Reader, expectedLog string) {
 	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, reader); err == nil {
+	var err error
+	if _, err = io.Copy(&buf, reader); err == nil {
 		assert.Equal(t, sanitizeString(expectedLog), sanitizeString(buf.String()))
 	}
+	assert.Nil(t, err)
 }
 
 func sanitizeString(str string) string {

--- a/pkg/ext/fetcher.go
+++ b/pkg/ext/fetcher.go
@@ -34,6 +34,9 @@ type AdminFetcherExtInterface interface {
 	// FetchAllVerOfLP fetches all versions of launch plan in a  project, domain
 	FetchAllVerOfLP(ctx context.Context, lpName, project, domain string, filter filters.Filters) ([]*admin.LaunchPlan, error)
 
+	// FetchAllLPs fetches all unique launch plans in a  project, domain
+	FetchAllLPs(ctx context.Context, project, domain string, filter filters.Filters) ([]*admin.NamedEntity, error)
+
 	// FetchLPLatestVersion fetches latest version of launch plan in a  project, domain
 	FetchLPLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.LaunchPlan, error)
 

--- a/pkg/ext/launch_plan_fetcher.go
+++ b/pkg/ext/launch_plan_fetcher.go
@@ -26,6 +26,22 @@ func (a *AdminFetcherExtClient) FetchAllVerOfLP(ctx context.Context, lpName, pro
 	return tList.LaunchPlans, nil
 }
 
+// FetchAllLPs fetches all launchplans in project domain
+func (a *AdminFetcherExtClient) FetchAllLPs(ctx context.Context, project, domain string, filter filters.Filters) ([]*admin.NamedEntity, error) {
+	tranformFilters, err := filters.BuildNamedEntityListRequest(filter, project, domain, core.ResourceType_LAUNCH_PLAN)
+	if err != nil {
+		return nil, err
+	}
+	wList, err := a.AdminServiceClient().ListNamedEntities(ctx, tranformFilters)
+	if err != nil {
+		return nil, err
+	}
+	if len(wList.Entities) == 0 {
+		return nil, fmt.Errorf("no launchplan retrieved for %v project %v domain", project, domain)
+	}
+	return wList.Entities, nil
+}
+
 // FetchLPLatestVersion fetches latest version for give launch plan name
 func (a *AdminFetcherExtClient) FetchLPLatestVersion(ctx context.Context, name, project, domain string, filter filters.Filters) (*admin.LaunchPlan, error) {
 	// Fetch the latest version of the task.

--- a/pkg/ext/mocks/admin_fetcher_ext_interface.go
+++ b/pkg/ext/mocks/admin_fetcher_ext_interface.go
@@ -53,6 +53,47 @@ func (_m *AdminFetcherExtInterface) AdminServiceClient() service.AdminServiceCli
 	return r0
 }
 
+type AdminFetcherExtInterface_FetchAllLPs struct {
+	*mock.Call
+}
+
+func (_m AdminFetcherExtInterface_FetchAllLPs) Return(_a0 []*admin.NamedEntity, _a1 error) *AdminFetcherExtInterface_FetchAllLPs {
+	return &AdminFetcherExtInterface_FetchAllLPs{Call: _m.Call.Return(_a0, _a1)}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchAllLPs(ctx context.Context, project string, domain string, filter filters.Filters) *AdminFetcherExtInterface_FetchAllLPs {
+	c_call := _m.On("FetchAllLPs", ctx, project, domain, filter)
+	return &AdminFetcherExtInterface_FetchAllLPs{Call: c_call}
+}
+
+func (_m *AdminFetcherExtInterface) OnFetchAllLPsMatch(matchers ...interface{}) *AdminFetcherExtInterface_FetchAllLPs {
+	c_call := _m.On("FetchAllLPs", matchers...)
+	return &AdminFetcherExtInterface_FetchAllLPs{Call: c_call}
+}
+
+// FetchAllLPs provides a mock function with given fields: ctx, project, domain, filter
+func (_m *AdminFetcherExtInterface) FetchAllLPs(ctx context.Context, project string, domain string, filter filters.Filters) ([]*admin.NamedEntity, error) {
+	ret := _m.Called(ctx, project, domain, filter)
+
+	var r0 []*admin.NamedEntity
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, filters.Filters) []*admin.NamedEntity); ok {
+		r0 = rf(ctx, project, domain, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*admin.NamedEntity)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, filters.Filters) error); ok {
+		r1 = rf(ctx, project, domain, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type AdminFetcherExtInterface_FetchAllVerOfLP struct {
 	*mock.Call
 }


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>


# TL;DR
Earlier response

```
flytectl get launchplan -p cluster-deploy -d development 
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| VERSION (100)                            | NAME                                                           | TYPE        | CREATEDAT                   |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| v3                                       | .flytegen.core.control_flow.dynamics.count_characters          | LAUNCH_PLAN | 2022-04-15T00:04:27.164048Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| v3                                       | .flytegen.core.control_flow.dynamics.derive_count              | LAUNCH_PLAN | 2022-01-06T19:43:06.386296Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.driver.update_multiple_orgs                          | LAUNCH_PLAN | 2021-08-16T23:59:19.832281Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.driver.create_org                                    | LAUNCH_PLAN | 2021-08-16T23:59:19.447806Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.driver.update_org                                    | LAUNCH_PLAN | 2021-08-16T23:59:18.968357Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.provision_user_flyte.complete_user_provisioning      | LAUNCH_PLAN | 2021-08-16T23:59:18.425521Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.provision_user_flyte.create_initial_opta_environment | LAUNCH_PLAN | 2021-08-16T23:59:17.811495Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | test_lp_3                                                      | LAUNCH_PLAN | 2021-08-16T23:59:16.863161Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | test_lp_2                                                      | LAUNCH_PLAN | 2021-08-16T23:59:16.756235Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | test_lp                                                        | LAUNCH_PLAN | 2021-08-16T23:59:16.648897Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.okta.test_schedule                                   | LAUNCH_PLAN | 2021-08-16T23:59:16.542805Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.okta.provision_okta                                  | LAUNCH_PLAN | 2021-08-16T23:59:16.184168Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.create_sub_account.create_sub_account                | LAUNCH_PLAN | 2021-08-16T23:59:15.290981Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| 4edd875cbe683f20023415de25c0cacd264f1f7e | workflows.provision_sub_account.provision_sub_account          | LAUNCH_PLAN | 2021-08-16T23:59:14.069152Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| d46d6894e27f61d7842388f7779682b19476e061 | workflows.driver.update_multiple_orgs                          | LAUNCH_PLAN | 2021-08-09T20:59:03.724519Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| d46d6894e27f61d7842388f7779682b19476e061 | workflows.driver.create_org                                    | LAUNCH_PLAN | 2021-08-09T20:59:03.346393Z |
 ------------------------------------------ ---------------------------------------------------------------- ------------- ----------------------------- 
| d46d6894e27f61d7842388f7779682b19476e061 | workflows.driver.update_org                                    | LAUNCH_PLAN | 2021-08-09T20:59:02.811781Z |
```

New response 


```
flytectl get launchplan -p cluster-deploy -d development 
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| PROJECT (41)   | DOMAIN      | NAME                                                                | DESCRIPTION | STATE |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | always_2_lp                                                         |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.dynamics.my_wf                                    |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.dynamics.wf                                       |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.map_task.my_map_workflow                          |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_conditions.basic_boolean_wf                   |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_conditions.bool_input_wf                      |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_conditions.multiplier                         |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_conditions.multiplier_2                       |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_conditions.multiplier_3                       |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.run_merge_sort.merge_sort                         |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.subworkflows.my_subwf                             |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.control_flow.subworkflows.parent_wf                            |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.extend_flyte.custom_task_plugin.my_workflow                    |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.extend_flyte.run_custom_types.wf                               |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.flyte_basics.basic_workflow.my_wf                              |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.flyte_basics.files.rotate_one_workflow                         |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.flyte_basics.folders.download_and_rotate                       |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
| cluster-deploy | development | core.flyte_basics.hello_world.my_wf                                 |             |       |
 ---------------- ------------- --------------------------------------------------------------------- ------------- ------- 
```


## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyteconsole/issues/298

## Follow-up issue
_NA_

