### PR TITLE
Using security context during registration along with authrole

### DIFF
--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -402,8 +402,14 @@ func hydrateLaunchPlanSpec(configAssumableIamRole string, configK8sServiceAccoun
 	outputLocationPrefix := len(configOutputLocationPrefix) > 0
 	if assumableIamRole || k8sServiceAcct {
 		lpSpec.AuthRole = &admin.AuthRole{
-			AssumableIamRole:         configAssumableIamRole,
 			KubernetesServiceAccount: configK8sServiceAccount,
+			AssumableIamRole:         configAssumableIamRole,
+		}
+		lpSpec.SecurityContext = &core.SecurityContext{
+			RunAs: &core.Identity{
+				IamRole:           configAssumableIamRole,
+				K8SServiceAccount: configK8sServiceAccount,
+			},
 		}
 	}
 	if outputLocationPrefix {

--- a/cmd/register/register_util_test.go
+++ b/cmd/register/register_util_test.go
@@ -347,6 +347,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		err := hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Nil(t, err)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole"}, lpSpec.AuthRole)
+		assert.Equal(t, &core.SecurityContext{RunAs: &core.Identity{IamRole: "iamRole"}}, lpSpec.SecurityContext)
 	})
 	t.Run("k8sService account override", func(t *testing.T) {
 		registerFilesSetup()
@@ -355,6 +356,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		err := hydrateLaunchPlanSpec(rconfig.DefaultFilesConfig.AssumableIamRole, rconfig.DefaultFilesConfig.K8sServiceAccount, rconfig.DefaultFilesConfig.OutputLocationPrefix, lpSpec)
 		assert.Nil(t, err)
 		assert.Equal(t, &admin.AuthRole{KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
+		assert.Equal(t, &core.SecurityContext{RunAs: &core.Identity{K8SServiceAccount: "k8Account"}}, lpSpec.SecurityContext)
 	})
 	t.Run("Both k8sService and IamRole", func(t *testing.T) {
 		registerFilesSetup()
@@ -365,6 +367,7 @@ func TestHydrateLaunchPlanSpec(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, &admin.AuthRole{AssumableIamRole: "iamRole",
 			KubernetesServiceAccount: "k8Account"}, lpSpec.AuthRole)
+		assert.Equal(t, &core.SecurityContext{RunAs: &core.Identity{IamRole: "iamRole", K8SServiceAccount: "k8Account"}}, lpSpec.SecurityContext)
 	})
 	t.Run("Output prefix", func(t *testing.T) {
 		registerFilesSetup()


### PR DESCRIPTION
Signed-off-by: Prafulla Mahindrakar <prafulla.mahindrakar@gmail.com>

# TL;DR

```
flytectl register file  /Users/praful/flytesnacks/cookbook/core/_pb_output/*schedule*  -d development  -p flytectldemo --version v6 --k8sServiceAccount avexampleworkflows
```

```
closure:
  createdAt: "2022-06-04T05:10:12.817371Z"
  expectedInputs: {}
  expectedOutputs: {}
  updatedAt: "2022-06-04T05:10:12.817371Z"
id:
  domain: development
  name: my_cron_scheduled_lp
  project: flytectldemo
  resourceType: LAUNCH_PLAN
  version: v6
spec:
  annotations: {}
  authRole:
    kubernetesServiceAccount: avexampleworkflows
  defaultInputs: {}
  entityMetadata:
    schedule:
      cronSchedule:
        schedule: '*/1 * * * *'
  fixedInputs: {}
  labels: {}
  rawOutputDataConfig: {}
  securityContext:
    runAs:
      k8sServiceAccount: avexampleworkflows
  workflowId:
    domain: development
    name: core.scheduled_workflows.lp_schedules.date_formatter_wf
    project: flytectldemo
    resourceType: WORKFLOW
    version: v6


```
## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
