### PR TITLE
Teardown logic shared for demo/sandbox cmds 

### DIFF
--- a/cmd/demo/start.go
+++ b/cmd/demo/start.go
@@ -72,7 +72,6 @@ eg : for passing multiple environment variables
 
 Usage
 `
-	demoContextName = "flyte-sandbox"
 )
 
 func startDemoCluster(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {

--- a/cmd/demo/teardown.go
+++ b/cmd/demo/teardown.go
@@ -2,17 +2,12 @@ package demo
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/flyteorg/flytectl/pkg/configutil"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
 
 	"github.com/flyteorg/flytectl/pkg/docker"
 
-	"github.com/docker/docker/api/types"
-	"github.com/enescakir/emoji"
-
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
-	"github.com/flyteorg/flytectl/pkg/k8s"
 )
 
 const (
@@ -33,33 +28,5 @@ func teardownDemoCluster(ctx context.Context, args []string, cmdCtx cmdCore.Comm
 	if err != nil {
 		return err
 	}
-
-	return tearDownDemo(ctx, cli)
-}
-
-func tearDownDemo(ctx context.Context, cli docker.Docker) error {
-	c, err := docker.GetSandbox(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if c != nil {
-		if err := cli.ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{
-			Force: true,
-		}); err != nil {
-			return err
-		}
-	}
-	if err := configutil.ConfigCleanup(); err != nil {
-		fmt.Printf("Config cleanup failed. Which Failed due to %v \n ", err)
-	}
-	if err := removeDemoKubeContext(); err != nil {
-		fmt.Printf("Kubecontext cleanup failed. Which Failed due to %v \n ", err)
-	}
-	fmt.Printf("%v %v Demo cluster is removed successfully. \n", emoji.Broom, emoji.Broom)
-	return nil
-}
-
-func removeDemoKubeContext() error {
-	k8sCtxMgr := k8s.NewK8sContextManager()
-	return k8sCtxMgr.RemoveContext(demoContextName)
+	return sandbox.Teardown(ctx, cli)
 }

--- a/cmd/demo/teardown_test.go
+++ b/cmd/demo/teardown_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flyteorg/flytectl/pkg/docker/mocks"
 	"github.com/flyteorg/flytectl/pkg/k8s"
 	k8sMocks "github.com/flyteorg/flytectl/pkg/k8s/mocks"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
 	"github.com/flyteorg/flytectl/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -36,7 +37,7 @@ func TestTearDownFunc(t *testing.T) {
 		mockK8sContextMgr := &k8sMocks.ContextOps{}
 		k8s.ContextMgr = mockK8sContextMgr
 		mockK8sContextMgr.OnRemoveContextMatch(mock.Anything).Return(nil)
-		err := tearDownDemo(ctx, mockDocker)
+		err := sandbox.Teardown(ctx, mockDocker)
 		assert.Nil(t, err)
 	})
 	t.Run("Error", func(t *testing.T) {
@@ -44,7 +45,15 @@ func TestTearDownFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
 		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
-		err := tearDownDemo(ctx, mockDocker)
+		err := sandbox.Teardown(ctx, mockDocker)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		ctx := context.Background()
+		mockDocker := &mocks.Docker{}
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
+		err := sandbox.Teardown(ctx, mockDocker)
 		assert.NotNil(t, err)
 	})
 

--- a/cmd/sandbox/start.go
+++ b/cmd/sandbox/start.go
@@ -76,7 +76,6 @@ eg : for passing multiple environment variables
 
 Usage
 `
-	sandboxContextName = "flyte-sandbox"
 )
 
 func startSandboxCluster(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {

--- a/cmd/sandbox/teardown.go
+++ b/cmd/sandbox/teardown.go
@@ -2,17 +2,11 @@ package sandbox
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/flyteorg/flytectl/pkg/configutil"
 
 	"github.com/flyteorg/flytectl/pkg/docker"
-
-	"github.com/docker/docker/api/types"
-	"github.com/enescakir/emoji"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
 
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
-	"github.com/flyteorg/flytectl/pkg/k8s"
 )
 
 const (
@@ -33,33 +27,5 @@ func teardownSandboxCluster(ctx context.Context, args []string, cmdCtx cmdCore.C
 	if err != nil {
 		return err
 	}
-
-	return tearDownSandbox(ctx, cli)
-}
-
-func tearDownSandbox(ctx context.Context, cli docker.Docker) error {
-	c, err := docker.GetSandbox(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if c != nil {
-		if err := cli.ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{
-			Force: true,
-		}); err != nil {
-			return err
-		}
-	}
-	if err := configutil.ConfigCleanup(); err != nil {
-		fmt.Printf("Config cleanup failed. Which Failed due to %v \n ", err)
-	}
-	if err := removeSandboxKubeContext(); err != nil {
-		fmt.Printf("Kubecontext cleanup failed. Which Failed due to %v \n ", err)
-	}
-	fmt.Printf("%v %v Sandbox cluster is removed successfully. \n", emoji.Broom, emoji.Broom)
-	return nil
-}
-
-func removeSandboxKubeContext() error {
-	k8sCtxMgr := k8s.NewK8sContextManager()
-	return k8sCtxMgr.RemoveContext(sandboxContextName)
+	return sandbox.Teardown(ctx, cli)
 }

--- a/cmd/sandbox/teardown_test.go
+++ b/cmd/sandbox/teardown_test.go
@@ -1,8 +1,6 @@
 package sandbox
 
 import (
-	"context"
-	"fmt"
 	"testing"
 
 	"github.com/docker/docker/api/types"
@@ -12,53 +10,13 @@ import (
 	"github.com/flyteorg/flytectl/pkg/docker/mocks"
 	"github.com/flyteorg/flytectl/pkg/k8s"
 	k8sMocks "github.com/flyteorg/flytectl/pkg/k8s/mocks"
-	"github.com/flyteorg/flytectl/pkg/sandbox"
 	"github.com/flyteorg/flytectl/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-var containers []types.Container
-
-func TestTearDownFunc(t *testing.T) {
-	container1 := types.Container{
-		ID: "FlyteSandboxClusterName",
-		Names: []string{
-			docker.FlyteSandboxClusterName,
-		},
-	}
-	containers = append(containers, container1)
-
-	t.Run("Success", func(t *testing.T) {
-		ctx := context.Background()
-		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
-		mockK8sContextMgr := &k8sMocks.ContextOps{}
-		k8s.ContextMgr = mockK8sContextMgr
-		mockK8sContextMgr.OnRemoveContextMatch(mock.Anything).Return(nil)
-		err := sandbox.Teardown(ctx, mockDocker)
-		assert.Nil(t, err)
-	})
-	t.Run("Error", func(t *testing.T) {
-		ctx := context.Background()
-		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
-		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
-		err := sandbox.Teardown(ctx, mockDocker)
-		assert.NotNil(t, err)
-	})
-	t.Run("Error", func(t *testing.T) {
-		ctx := context.Background()
-		mockDocker := &mocks.Docker{}
-		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
-		err := sandbox.Teardown(ctx, mockDocker)
-		assert.NotNil(t, err)
-	})
-
-}
-
 func TestTearDownClusterFunc(t *testing.T) {
+	var containers []types.Container
 	_ = util.SetupFlyteDir()
 	_ = util.WriteIntoFile([]byte("data"), configutil.FlytectlConfig)
 	s := testutils.Setup()
@@ -66,6 +24,10 @@ func TestTearDownClusterFunc(t *testing.T) {
 	mockDocker := &mocks.Docker{}
 	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
 	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+	mockK8sContextMgr := &k8sMocks.ContextOps{}
+	mockK8sContextMgr.OnRemoveContext(mock.Anything).Return(nil)
+	k8s.ContextMgr = mockK8sContextMgr
+
 	docker.Client = mockDocker
 	err := teardownSandboxCluster(ctx, []string{}, s.CmdCtx)
 	assert.Nil(t, err)

--- a/cmd/sandbox/teardown_test.go
+++ b/cmd/sandbox/teardown_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/flyteorg/flytectl/pkg/docker/mocks"
 	"github.com/flyteorg/flytectl/pkg/k8s"
 	k8sMocks "github.com/flyteorg/flytectl/pkg/k8s/mocks"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
 	"github.com/flyteorg/flytectl/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -36,7 +37,7 @@ func TestTearDownFunc(t *testing.T) {
 		mockK8sContextMgr := &k8sMocks.ContextOps{}
 		k8s.ContextMgr = mockK8sContextMgr
 		mockK8sContextMgr.OnRemoveContextMatch(mock.Anything).Return(nil)
-		err := tearDownSandbox(ctx, mockDocker)
+		err := sandbox.Teardown(ctx, mockDocker)
 		assert.Nil(t, err)
 	})
 	t.Run("Error", func(t *testing.T) {
@@ -44,7 +45,14 @@ func TestTearDownFunc(t *testing.T) {
 		mockDocker := &mocks.Docker{}
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
 		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
-		err := tearDownSandbox(ctx, mockDocker)
+		err := sandbox.Teardown(ctx, mockDocker)
+		assert.NotNil(t, err)
+	})
+	t.Run("Error", func(t *testing.T) {
+		ctx := context.Background()
+		mockDocker := &mocks.Docker{}
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
+		err := sandbox.Teardown(ctx, mockDocker)
 		assert.NotNil(t, err)
 	})
 

--- a/pkg/sandbox/teardown.go
+++ b/pkg/sandbox/teardown.go
@@ -1,0 +1,39 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"github.com/enescakir/emoji"
+	"github.com/flyteorg/flytectl/pkg/configutil"
+	"github.com/flyteorg/flytectl/pkg/docker"
+	"github.com/flyteorg/flytectl/pkg/k8s"
+)
+
+func Teardown(ctx context.Context, cli docker.Docker) error {
+	c, err := docker.GetSandbox(ctx, cli)
+	if err != nil {
+		return err
+	}
+	if c != nil {
+		if err := cli.ContainerRemove(context.Background(), c.ID, types.ContainerRemoveOptions{
+			Force: true,
+		}); err != nil {
+			return err
+		}
+	}
+	if err := configutil.ConfigCleanup(); err != nil {
+		fmt.Printf("Config cleanup failed. Which Failed due to %v \n ", err)
+	}
+	if err := removeSandboxKubeContext(); err != nil {
+		fmt.Printf("Kubecontext cleanup failed. Which Failed due to %v \n ", err)
+	}
+	fmt.Printf("%v %v Sandbox cluster is removed successfully. \n", emoji.Broom, emoji.Broom)
+	return nil
+}
+
+func removeSandboxKubeContext() error {
+	k8sCtxMgr := k8s.NewK8sContextManager()
+	return k8sCtxMgr.RemoveContext(sandboxContextName)
+}

--- a/pkg/sandbox/teardown_test.go
+++ b/pkg/sandbox/teardown_test.go
@@ -1,0 +1,48 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/flyteorg/flytectl/pkg/docker"
+	"github.com/flyteorg/flytectl/pkg/docker/mocks"
+	"github.com/flyteorg/flytectl/pkg/k8s"
+	k8sMocks "github.com/flyteorg/flytectl/pkg/k8s/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestTearDownFunc(t *testing.T) {
+	var containers []types.Container
+	container1 := types.Container{
+		ID: "FlyteSandboxClusterName",
+		Names: []string{
+			docker.FlyteSandboxClusterName,
+		},
+	}
+	containers = append(containers, container1)
+	ctx := context.Background()
+
+	mockDocker := &mocks.Docker{}
+	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("err"))
+	err := Teardown(ctx, mockDocker)
+	assert.NotNil(t, err)
+
+	mockDocker = &mocks.Docker{}
+	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(nil, fmt.Errorf("err"))
+	err = Teardown(ctx, mockDocker)
+	assert.NotNil(t, err)
+
+	mockDocker = &mocks.Docker{}
+	mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return(containers, nil)
+	mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(nil)
+	mockK8sContextMgr := &k8sMocks.ContextOps{}
+	mockK8sContextMgr.OnRemoveContext(mock.Anything).Return(nil)
+	k8s.ContextMgr = mockK8sContextMgr
+	err = Teardown(ctx, mockDocker)
+	assert.Nil(t, err)
+
+}


### PR DESCRIPTION

# TL;DR
Logic for tearing down sandbox and demo is redundant. This PR unifies teardown logic under a pkg/sandbox package

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Unifying repeated logic to `pkg/sandbox`. The groundwork was already done for the start cmd.
- Ran unitests. 
- Created a sandbox and demo clusters then tore them down successfully

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2472

## Follow-up issue
_NA_
