### PR TITLE
#minor Fixes the project name and workflow name in the flytectl documentation.

### DIFF
--- a/cmd/create/execution.go
+++ b/cmd/create/execution.go
@@ -20,7 +20,7 @@ There are three steps to generate an execution, as outlined below:
 1. Generate the execution spec file using the :ref:` + "`get task <flytectl_get_task>`" + ` command.
 ::
 
-	flytectl get tasks -d development -p flytectldemo core.advanced.run_merge_sort.merge --version v2 --execFile execution_spec.yaml
+	flytectl get tasks -d development -p flytesnacks core.control_flow.merge_sort.merge --version v2 --execFile execution_spec.yaml
 
 The generated file would look similar to the following:
 
@@ -35,7 +35,7 @@ The generated file would look similar to the following:
 	kubeServiceAcct: ""
 	targetDomain: ""
 	targetProject: ""
-	task: core.advanced.run_merge_sort.merge
+	task: core.control_flow.merge_sort.merge
 	version: "v2"
 
 2. [Optional] Update the inputs for the execution, if needed.
@@ -56,7 +56,7 @@ The generated spec file can be modified to change the input values, as shown bel
 	kubeServiceAcct: ""
 	targetDomain: ""
 	targetProject: ""
-	task: core.advanced.run_merge_sort.merge
+	task: core.control_flow.merge_sort.merge
 	version: "v2"
 
 3. Run the execution by passing the generated YAML file.
@@ -70,13 +70,13 @@ To relaunch an execution, pass the current execution ID as follows:
 
 ::
 
- flytectl create execution --relaunch ffb31066a0f8b4d52b77 -p flytectldemo -d development
+ flytectl create execution --relaunch ffb31066a0f8b4d52b77 -p flytesnacks -d development
 
 To recover an execution, i.e., recreate it from the last known failure point for previously-run workflow execution, run:
 
 ::
 
- flytectl create execution --recover ffb31066a0f8b4d52b77 -p flytectldemo -d development
+ flytectl create execution --recover ffb31066a0f8b4d52b77 -p flytesnacks -d development
 
 See :ref:` + "`ref_flyteidl.admin.ExecutionRecoverRequest`" + ` for more details.
 
@@ -85,7 +85,7 @@ The following is an example of how generic data can be specified while creating 
 
 ::
 
- flytectl get task -d development -p flytectldemo  core.type_system.custom_objects.add --execFile adddatanum.yaml
+ flytectl get task -d development -p flytesnacks  core.type_system.custom_objects.add --execFile adddatanum.yaml
 
 The generated file would look similar to this. Here, empty values have been dumped for generic data types 'x' and 'y'.
 ::

--- a/cmd/create/execution_test.go
+++ b/cmd/create/execution_test.go
@@ -111,7 +111,7 @@ func createExecutionSetup(s *testutils.TestStruct) (t TestStruct) {
 	}
 	launchPlan1 := &admin.LaunchPlan{
 		Id: &core.Identifier{
-			Name:    "core.advanced.run_merge_sort.merge_sort",
+			Name:    "core.control_flow.merge_sort.merge_sort",
 			Version: "v3",
 		},
 		Spec: &admin.LaunchPlanSpec{
@@ -131,7 +131,7 @@ func createExecutionSetup(s *testutils.TestStruct) (t TestStruct) {
 			ResourceType: core.ResourceType_LAUNCH_PLAN,
 			Project:      config.GetConfig().Project,
 			Domain:       config.GetConfig().Domain,
-			Name:         "core.advanced.run_merge_sort.merge_sort",
+			Name:         "core.control_flow.merge_sort.merge_sort",
 			Version:      "v2",
 		},
 	}

--- a/cmd/delete/matchable_cluster_resource_attribute.go
+++ b/cmd/delete/matchable_cluster_resource_attribute.go
@@ -15,10 +15,10 @@ const (
 	clusterResourceAttributesLong  = `
 Delete cluster resource attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete cluster-resource-attribute -p flytectldemo -d development
+ flytectl delete cluster-resource-attribute -p flytesnacks -d development
 
 
 To delete cluster resource attribute using the config file that was used to create it, run:
@@ -32,18 +32,18 @@ For example, here's the config file cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"
 
 Attributes are optional in the file, which are unread during the 'delete' command but can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete cluster resource attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run:
+To delete cluster resource attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run:
 
 ::
 
- flytectl delete cluster-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete cluster-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_cluster_resource_attribute_test.go
+++ b/cmd/delete/matchable_cluster_resource_attribute_test.go
@@ -54,7 +54,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 		err := deleteClusterResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_CLUSTER_RESOURCE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -96,7 +96,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 		err := deleteClusterResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 		err := deleteClusterResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -125,6 +125,6 @@ func TestDeleteClusterResourceAttributes(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_CLUSTER_RESOURCE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_CLUSTER_RESOURCE)
 	})
 }

--- a/cmd/delete/matchable_execution_cluster_label.go
+++ b/cmd/delete/matchable_execution_cluster_label.go
@@ -15,10 +15,10 @@ const (
 	executionClusterLabelLong  = `
 Delete execution cluster label for a given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete execution-cluster-label -p flytectldemo -d development
+ flytectl delete execution-cluster-label -p flytesnacks -d development
 
 To delete execution cluster label using the config file that was used to create it, run:
 
@@ -31,16 +31,16 @@ For example, here's the config file ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 Value is optional in the file as it is unread during the delete command, but it can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete the execution cluster label of the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following:
+To delete the execution cluster label of the workflow 'core.control_flow.merge_sort.merge_sort', run the following:
 
 ::
 
- flytectl delete execution-cluster-label -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete execution-cluster-label -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_execution_cluster_label_test.go
+++ b/cmd/delete/matchable_execution_cluster_label_test.go
@@ -54,7 +54,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 		err := deleteExecutionClusterLabel(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -96,7 +96,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 		err := deleteExecutionClusterLabel(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 		err := deleteExecutionClusterLabel(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -125,6 +125,6 @@ func TestDeleteExecutionClusterLabels(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_CLUSTER_LABEL)
 	})
 }

--- a/cmd/delete/matchable_execution_queue_attribute.go
+++ b/cmd/delete/matchable_execution_queue_attribute.go
@@ -15,10 +15,10 @@ const (
 	executionQueueAttributesLong  = `
 Delete execution queue attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete execution-queue-attribute -p flytectldemo -d development
+ flytectl delete execution-queue-attribute -p flytesnacks -d development
 
 Delete execution queue attribute using the config file which was used to create it.
 
@@ -31,7 +31,7 @@ For example, here's the config file era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar
@@ -40,11 +40,11 @@ For example, here's the config file era.yaml:
 
 Value is optional in the file as it is unread during the delete command but it can be retained since the same file can be used for get, update and delete commands.
 
-To delete the execution queue attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete the execution queue attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete execution-queue-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete execution-queue-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_execution_queue_attribute_test.go
+++ b/cmd/delete/matchable_execution_queue_attribute_test.go
@@ -54,7 +54,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 		err := deleteExecutionQueueAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_EXECUTION_QUEUE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -96,7 +96,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 		err := deleteExecutionQueueAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 		err := deleteExecutionQueueAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_EXECUTION_QUEUE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -125,6 +125,6 @@ func TestDeleteExecutionQueueAttributes(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_EXECUTION_QUEUE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_EXECUTION_QUEUE)
 	})
 }

--- a/cmd/delete/matchable_plugin_override.go
+++ b/cmd/delete/matchable_plugin_override.go
@@ -15,10 +15,10 @@ const (
 	pluginOverrideLong  = `
 Delete plugin override for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete plugin-override -p flytectldemo -d development
+ flytectl delete plugin-override -p flytesnacks -d development
 
 
 To delete plugin override using the config file which was used to create it, run:
@@ -31,7 +31,7 @@ For example, here's the config file po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.
@@ -41,11 +41,11 @@ For example, here's the config file po.yaml:
 
 Overrides are optional in the file as they are unread during the delete command but can be retained since the same file can be used for get, update and delete commands.
 
-To delete plugin override for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete plugin override for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete plugin-override -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete plugin-override -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_plugin_override_test.go
+++ b/cmd/delete/matchable_plugin_override_test.go
@@ -54,7 +54,7 @@ func TestPluginOverride(t *testing.T) {
 		err := deletePluginOverride(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -96,7 +96,7 @@ func TestPluginOverride(t *testing.T) {
 		err := deletePluginOverride(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestPluginOverride(t *testing.T) {
 		err := deletePluginOverride(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -125,6 +125,6 @@ func TestPluginOverride(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_PLUGIN_OVERRIDE)
 	})
 }

--- a/cmd/delete/matchable_task_resource_attribute.go
+++ b/cmd/delete/matchable_task_resource_attribute.go
@@ -15,10 +15,10 @@ const (
 	taskResourceAttributesLong  = `
 Delete task resource attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete task-resource-attribute -p flytectldemo -d development
+ flytectl delete task-resource-attribute -p flytesnacks -d development
 
 To delete task resource attribute using the config file which was used to create it, run:
 
@@ -31,7 +31,7 @@ For example, here's the config file tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"
@@ -41,11 +41,11 @@ For example, here's the config file tra.yaml:
 
 The defaults/limits are optional in the file as they are unread during the delete command, but can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete task resource attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete task resource attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete task-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete task-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_task_resource_attribute_test.go
+++ b/cmd/delete/matchable_task_resource_attribute_test.go
@@ -54,7 +54,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 		err := deleteTaskResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_TASK_RESOURCE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -96,7 +96,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 		err := deleteTaskResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 		err := deleteTaskResourceAttributes(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_TASK_RESOURCE)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -125,6 +125,6 @@ func TestDeleteTaskResourceAttributes(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_TASK_RESOURCE)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_TASK_RESOURCE)
 	})
 }

--- a/cmd/delete/matchable_workflow_execution_config.go
+++ b/cmd/delete/matchable_workflow_execution_config.go
@@ -16,10 +16,10 @@ const (
 	workflowExecutionConfigLong  = `
 Delete workflow execution config for the given project and domain combination or additionally the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete workflow-execution-config -p flytectldemo -d development
+ flytectl delete workflow-execution-config -p flytesnacks -d development
 
 To delete workflow execution config using the config file which was used to create it, run:
 
@@ -32,7 +32,7 @@ For example, here's the config file wec.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 	security_context:
   		run_as:
@@ -40,11 +40,11 @@ For example, here's the config file wec.yaml:
 
 Max_parallelism is optional in the file as it is unread during the delete command but can be retained since the same file can be used for get, update and delete commands.
 
-To delete workflow execution config for the workflow 'core.control_flow.run_merge_sort.merge_sort', run:
+To delete workflow execution config for the workflow 'core.control_flow.merge_sort.merge_sort', run:
 
 ::
 
- flytectl delete workflow-execution-config -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete workflow-execution-config -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 `

--- a/cmd/delete/matchable_workflow_execution_config_test.go
+++ b/cmd/delete/matchable_workflow_execution_config_test.go
@@ -55,7 +55,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 		err := deleteWorkflowExecutionConfig(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("successful workflow attribute deletion", func(t *testing.T) {
 		s := setup()
@@ -97,7 +97,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 		err := deleteWorkflowExecutionConfig(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
 		s.DeleterExt.AssertCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("workflow attribute deletion non existent file", func(t *testing.T) {
@@ -111,7 +111,7 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 		err := deleteWorkflowExecutionConfig(s.Ctx, []string{}, s.CmdCtx)
 		assert.NotNil(t, err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteWorkflowAttributes",
-			s.Ctx, "flytectldemo", "development", "core.control_flow.run_merge_sort.merge_sort",
+			s.Ctx, "flytesnacks", "development", "core.control_flow.merge_sort.merge_sort",
 			admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 	t.Run("attribute deletion invalid file", func(t *testing.T) {
@@ -126,6 +126,6 @@ func TestDeleteWorkflowExecutionConfig(t *testing.T) {
 			fmt.Errorf("error unmarshaling JSON: while decoding JSON: json: unknown field \"InvalidDomain\""),
 			err)
 		s.DeleterExt.AssertNotCalled(t, "DeleteProjectDomainAttributes",
-			s.Ctx, "flytectldemo", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
+			s.Ctx, "flytesnacks", "development", admin.MatchableResource_WORKFLOW_EXECUTION_CONFIG)
 	})
 }

--- a/cmd/delete/testdata/invalid_attribute.yaml
+++ b/cmd/delete/testdata/invalid_attribute.yaml
@@ -1,5 +1,5 @@
 InvalidDomain: development
-InvalidProject: flytectldemo
+InvalidProject: flytesnacks
 InvalidWorkflow: ""
 cpu: "1"
 memory: 150Mi

--- a/cmd/delete/testdata/valid_project_domain_cluster_attribute.yaml
+++ b/cmd/delete/testdata/valid_project_domain_cluster_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 attributes:
   "foo": "bar"
   "buzz": "lightyear"

--- a/cmd/delete/testdata/valid_project_domain_execution_cluster_label.yaml
+++ b/cmd/delete/testdata/valid_project_domain_execution_cluster_label.yaml
@@ -1,3 +1,3 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 value: foo

--- a/cmd/delete/testdata/valid_project_domain_execution_queue_attribute.yaml
+++ b/cmd/delete/testdata/valid_project_domain_execution_queue_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 tags:
   - foo
   - bar

--- a/cmd/delete/testdata/valid_project_domain_plugin_override.yaml
+++ b/cmd/delete/testdata/valid_project_domain_plugin_override.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 overrides:
   - task_type: python_task
     plugin_id:

--- a/cmd/delete/testdata/valid_project_domain_task_attribute.yaml
+++ b/cmd/delete/testdata/valid_project_domain_task_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 defaults:
   cpu: "1"
   memory: 150Mi

--- a/cmd/delete/testdata/valid_project_domain_workflow_execution_config.yaml
+++ b/cmd/delete/testdata/valid_project_domain_workflow_execution_config.yaml
@@ -1,3 +1,3 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 max_parallelism: 5

--- a/cmd/delete/testdata/valid_workflow_cluster_attribute.yaml
+++ b/cmd/delete/testdata/valid_workflow_cluster_attribute.yaml
@@ -1,6 +1,6 @@
 Domain: development
-Project: flytectldemo
-Workflow: core.control_flow.run_merge_sort.merge_sort
+Project: flytesnacks
+Workflow: core.control_flow.merge_sort.merge_sort
 attributes:
   "foo": "bar"
   "buzz": "lightyear"

--- a/cmd/delete/testdata/valid_workflow_execution_cluster_label.yaml
+++ b/cmd/delete/testdata/valid_workflow_execution_cluster_label.yaml
@@ -1,4 +1,4 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 value: foo

--- a/cmd/delete/testdata/valid_workflow_execution_queue_attribute.yaml
+++ b/cmd/delete/testdata/valid_workflow_execution_queue_attribute.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 tags:
   - foo
   - bar

--- a/cmd/delete/testdata/valid_workflow_plugin_override.yaml
+++ b/cmd/delete/testdata/valid_workflow_plugin_override.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 overrides:
   - task_type: python_task
     plugin_id:

--- a/cmd/delete/testdata/valid_workflow_task_attribute.yaml
+++ b/cmd/delete/testdata/valid_workflow_task_attribute.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 defaults:
   cpu: "2"
   memory: 250Mi

--- a/cmd/delete/testdata/valid_workflow_workflow_execution_config.yaml
+++ b/cmd/delete/testdata/valid_workflow_workflow_execution_config.yaml
@@ -1,4 +1,4 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 max_parallelism: 5

--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -97,7 +97,7 @@ Retrieve a launch plan within the project and domain as per a version and genera
 
 ::
 
- flytectl get launchplan -d development -p flytectldemo core.advanced.run_merge_sort.merge_sort --execFile execution_spec.yaml
+ flytectl get launchplan -d development -p flytesnacks core.control_flow.merge_sort.merge_sort --execFile execution_spec.yaml
 
 The generated file would look similar to this:
 
@@ -113,7 +113,7 @@ The generated file would look similar to this:
 	 targetDomain: ""
 	 targetProject: ""
 	 version: v3
-	 workflow: core.advanced.run_merge_sort.merge_sort
+	 workflow: core.control_flow.merge_sort.merge_sort
 
 Check the :ref:` + "`create execution section<flytectl_create_execution>`" + ` on how to launch one using the generated file.
 Usage

--- a/cmd/get/matchable_cluster_resource_attribute.go
+++ b/cmd/get/matchable_cluster_resource_attribute.go
@@ -14,28 +14,28 @@ const (
 	clusterResourceAttributesShort = "Gets matchable resources of cluster resource attributes."
 	clusterResourceAttributesLong  = `
 Retrieve cluster resource attributes for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get cluster-resource-attribute -p flytectldemo -d development 
+ flytectl get cluster-resource-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","attributes":{"buzz":"lightyear","foo":"bar"}}
+ {"project":"flytesnacks","domain":"development","attributes":{"buzz":"lightyear","foo":"bar"}}
 
 Retrieve cluster resource attributes for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get cluster-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get cluster-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","attributes":{"buzz":"lightyear","foo":"bar"}}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","attributes":{"buzz":"lightyear","foo":"bar"}}
 
 Write the cluster resource attributes to a file. If there are no cluster resource attributes, the command throws an error.
 The config file is written to cra.yaml file.
@@ -49,7 +49,7 @@ Example: content of cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"

--- a/cmd/get/matchable_execution_cluster_label.go
+++ b/cmd/get/matchable_execution_cluster_label.go
@@ -15,28 +15,28 @@ const (
 	executionClusterLabelLong  = `
 Retrieve the execution cluster label for a given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl get execution-cluster-label -p flytectldemo -d development 
+ flytectl get execution-cluster-label -p flytesnacks -d development
 
 The output would look like:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","value":"foo"}
+ {"project":"flytesnacks","domain":"development","value":"foo"}
 
 Retrieve the execution cluster label for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get execution-cluster-label -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get execution-cluster-label -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","value":"foo"}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","value":"foo"}
 
 Write the execution cluster label to a file. If there is no execution cluster label, the command throws an error.
 The config file is written to ecl.yaml file.
@@ -50,7 +50,7 @@ Example: content of ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 Usage

--- a/cmd/get/matchable_execution_queue_attribute.go
+++ b/cmd/get/matchable_execution_queue_attribute.go
@@ -14,28 +14,28 @@ const (
 	executionQueueAttributesShort = "Gets matchable resources of execution queue attributes."
 	executionQueueAttributesLong  = `
 Retrieve the execution queue attribute for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get execution-queue-attribute -p flytectldemo -d development 
+ flytectl get execution-queue-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","tags":["foo", "bar"]}
+ {"project":"flytesnacks","domain":"development","tags":["foo", "bar"]}
 
 Retrieve the execution queue attribute for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get execution-queue-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get execution-queue-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","tags":["foo", "bar"]}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","tags":["foo", "bar"]}
 
 Write the execution queue attribute to a file. If there are no execution queue attributes, the command throws an error.
 The config file is written to era.yaml file.
@@ -49,7 +49,7 @@ Example: content of era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar

--- a/cmd/get/matchable_plugin_override.go
+++ b/cmd/get/matchable_plugin_override.go
@@ -14,18 +14,18 @@ const (
 	pluginOverrideShort = "Gets matchable resources of plugin override."
 	pluginOverrideLong  = `
 Retrieve the plugin override for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 
 ::
 
- flytectl get plugin-override -p flytectldemo -d development 
+ flytectl get plugin-override -p flytesnacks -d development
 
 Example: output from the command
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
 	"overrides": [{
 		"task_type": "python_task",
@@ -35,19 +35,19 @@ Example: output from the command
  }
 
 Retrieve the plugin override for the given project, domain, and workflow.
-For project flytectldemo, development domain and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get plugin-override -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get plugin-override -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
-    "workflow": "core.control_flow.run_merge_sort.merge_sort"
+    "workflow": "core.control_flow.merge_sort.merge_sort"
 	"overrides": [{
 		"task_type": "python_task",
 		"plugin_id": ["pluginoverride1", "pluginoverride2"],
@@ -67,7 +67,7 @@ Example: content of po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.

--- a/cmd/get/matchable_task_resource_attribute.go
+++ b/cmd/get/matchable_task_resource_attribute.go
@@ -14,28 +14,28 @@ const (
 	taskResourceAttributesShort = "Gets matchable resources of task attributes."
 	taskResourceAttributesLong  = `
 Retrieve task resource attributes for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get task-resource-attribute -p flytectldemo -d development 
+ flytectl get task-resource-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
+ {"project":"flytesnacks","domain":"development","workflow":"","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
 
 Retrieve task resource attributes for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get task-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get task-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
 
 
 Write the task resource attributes to a file. If there are no task resource attributes, a file would be populated with the basic data.
@@ -50,7 +50,7 @@ Example: content of tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"

--- a/cmd/get/matchable_workflow_execution_config.go
+++ b/cmd/get/matchable_workflow_execution_config.go
@@ -20,37 +20,37 @@ const (
 	workflowExecutionConfigLong  = `
 Retrieve workflow execution config for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development 
+ flytectl get workflow-execution-config -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
 	"max_parallelism": 5
  }
 
 Retrieve workflow execution config for the project, domain, and workflow.
-For project flytectldemo, development domain and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain and workflow 'core.control_flow.merge_sort.merge_sort':
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get workflow-execution-config -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
-    "workflow": "core.control_flow.run_merge_sort.merge_sort"
+    "workflow": "core.control_flow.merge_sort.merge_sort"
 	"max_parallelism": 5
  }
 
@@ -60,13 +60,13 @@ Example: content of wec.yaml:
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development --attrFile wec.yaml
+ flytectl get workflow-execution-config -p flytesnacks -d development --attrFile wec.yaml
 
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 
 Generate a sample workflow execution config file to be used for creating a new workflow execution config at project domain

--- a/cmd/get/task.go
+++ b/cmd/get/task.go
@@ -78,7 +78,7 @@ Retrieve tasks within project and domain for a version and generate the executio
 
 ::
 
- flytectl get tasks -d development -p flytesnacks core.advanced.run_merge_sort.merge --execFile execution_spec.yaml --version v2
+ flytectl get tasks -d development -p flytesnacks core.control_flow.merge_sort.merge --execFile execution_spec.yaml --version v2
 
 The generated file would look similar to this:
 
@@ -93,7 +93,7 @@ The generated file would look similar to this:
 	 kubeServiceAcct: ""
 	 targetDomain: ""
 	 targetProject: ""
-	 task: core.advanced.run_merge_sort.merge
+	 task: core.control_flow.merge_sort.merge
 	 version: v2
 
 Check the create execution section on how to launch one using the generated file.

--- a/cmd/testdata/invalid_execution_spec.yaml
+++ b/cmd/testdata/invalid_execution_spec.yaml
@@ -8,5 +8,5 @@ kubeServiceAcct: ""
 targetDomain: ""
 targetProject: ""
 version: v3
-workflow: core.advanced.run_merge_sort.merge_sort
-task: core.advanced.run_merge_sort.merge
+workflow: core.control_flow.merge_sort.merge_sort
+task: core.control_flow.merge_sort.merge

--- a/cmd/testdata/launchplan_execution_spec.yaml
+++ b/cmd/testdata/launchplan_execution_spec.yaml
@@ -8,4 +8,4 @@ kubeServiceAcct: ""
 targetDomain: ""
 targetProject: ""
 version: v3
-workflow: core.advanced.run_merge_sort.merge_sort
+workflow: core.control_flow.merge_sort.merge_sort

--- a/cmd/testdata/task_execution_spec.yaml
+++ b/cmd/testdata/task_execution_spec.yaml
@@ -11,5 +11,5 @@ inputs:
 kubeServiceAcct: "kubeServiceAcct"
 targetDomain: "development"
 targetProject: "flytesnacks"
-task: core.advanced.run_merge_sort.merge
+task: core.control_flow.merge_sort.merge
 version: v2

--- a/cmd/testdata/task_execution_spec_with_iamrole.yaml
+++ b/cmd/testdata/task_execution_spec_with_iamrole.yaml
@@ -11,5 +11,5 @@ inputs:
 kubeServiceAcct: ""
 targetDomain: "development"
 targetProject: "flytesnacks"
-task: core.advanced.run_merge_sort.merge
+task: core.control_flow.merge_sort.merge
 version: v2

--- a/cmd/update/execution.go
+++ b/cmd/update/execution.go
@@ -19,12 +19,12 @@ const (
 Activate an execution; and it shows up in the CLI and UI:
 ::
 
- flytectl update execution -p flytectldemo -d development  oeh94k9r2r --activate
+ flytectl update execution -p flytesnacks -d development  oeh94k9r2r --activate
 
 Archive an execution; and it is hidden from the CLI and UI:
 ::
 
- flytectl update execution -p flytectldemo -d development  oeh94k9r2r --archive
+ flytectl update execution -p flytesnacks -d development  oeh94k9r2r --archive
 
 
 Usage

--- a/cmd/update/launch_plan.go
+++ b/cmd/update/launch_plan.go
@@ -19,12 +19,12 @@ const (
 Activates a launch plan which activates the scheduled job associated with it:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --version v1 --activate
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --activate
 
 Archives a launch plan which deschedules any scheduled job associated with it:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --version v1 --archive
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --archive
 
 
 Usage

--- a/cmd/update/launch_plan_meta.go
+++ b/cmd/update/launch_plan_meta.go
@@ -16,17 +16,17 @@ const (
 Update the description on the launch plan:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --description "Mergesort example"
+ flytectl update launchplan -p flytesnacks -d development  core.advanced.merge_sort.merge_sort --description "Mergesort example"
 
 Archiving launch plan named entity is not supported and would throw an error:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --archive
+ flytectl update launchplan -p flytesnacks -d development  core.advanced.merge_sort.merge_sort --archive
 
 Activating launch plan named entity would be a noop:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --activate
+ flytectl update launchplan -p flytesnacks -d development  core.advanced.merge_sort.merge_sort --activate
 
 Usage
 `

--- a/cmd/update/matchable_cluster_resource_attribute.go
+++ b/cmd/update/matchable_cluster_resource_attribute.go
@@ -21,7 +21,7 @@ Example: content of cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"
@@ -35,13 +35,13 @@ resource attribute defined at project domain level.
 This will completely overwrite any existing custom project, domain and workflow combination attributes.
 It is preferable to do get and generate an attribute file if there is an existing attribute that is already set and then update it to have new values.
 Refer to get cluster-resource-attribute section on how to generate this file.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     attributes:
       foo: "bar"
       buzz: "lightyear"

--- a/cmd/update/matchable_cluster_resource_attribute_test.go
+++ b/cmd/update/matchable_cluster_resource_attribute_test.go
@@ -31,7 +31,7 @@ func TestUpdateClusterResourceAttributes(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updateClusterResourceAttributesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed to update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -54,7 +54,7 @@ func TestUpdateClusterResourceAttributes(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updateClusterResourceAttributesFunc(s.Ctx, nil, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed to update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/matchable_execution_cluster_label.go
+++ b/cmd/update/matchable_execution_cluster_label.go
@@ -21,7 +21,7 @@ Example: content of ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 ::
@@ -30,13 +30,13 @@ Example: content of ecl.yaml:
 
 Update execution cluster label for project, domain, and workflow combination. This will take precedence over any other
 execution cluster label defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     value: foo
 
 ::

--- a/cmd/update/matchable_execution_cluster_label_test.go
+++ b/cmd/update/matchable_execution_cluster_label_test.go
@@ -31,7 +31,7 @@ func TestExecutionClusterLabel(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updateExecutionClusterLabelFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -54,7 +54,7 @@ func TestExecutionClusterLabel(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updateExecutionClusterLabelFunc(s.Ctx, nil, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/matchable_execution_queue_attribute.go
+++ b/cmd/update/matchable_execution_queue_attribute.go
@@ -24,7 +24,7 @@ Example: content of era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar
@@ -37,13 +37,13 @@ Example: content of era.yaml:
 
 Update execution queue attribute for project, domain, and workflow combination. This will take precedence over any other
 execution queue attribute defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     tags:
       - foo
       - bar

--- a/cmd/update/matchable_execution_queue_attribute_test.go
+++ b/cmd/update/matchable_execution_queue_attribute_test.go
@@ -31,7 +31,7 @@ func TestExecutionQueueAttributes(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updateExecutionQueueAttributesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -54,7 +54,7 @@ func TestExecutionQueueAttributes(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updateExecutionQueueAttributesFunc(s.Ctx, nil, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/matchable_plugin_override.go
+++ b/cmd/update/matchable_plugin_override.go
@@ -24,7 +24,7 @@ Example: content of po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.
@@ -38,13 +38,13 @@ Example: content of po.yaml:
 
 Update plugin override for project, domain, and workflow combination. This will take precedence over any other
 plugin overrides defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.

--- a/cmd/update/matchable_plugin_override_test.go
+++ b/cmd/update/matchable_plugin_override_test.go
@@ -31,7 +31,7 @@ func TestPluginOverride(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updatePluginOverridesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -54,7 +54,7 @@ func TestPluginOverride(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updatePluginOverridesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/matchable_task_resource_attribute.go
+++ b/cmd/update/matchable_task_resource_attribute.go
@@ -24,7 +24,7 @@ Example: content of tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"
@@ -38,13 +38,13 @@ Example: content of tra.yaml:
 
 Update task resource attribute for project, domain, and workflow combination. This will take precedence over any other
 resource attribute defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     defaults:
       cpu: "1"
       memory: "150Mi"

--- a/cmd/update/matchable_task_resource_attribute_test.go
+++ b/cmd/update/matchable_task_resource_attribute_test.go
@@ -31,7 +31,7 @@ func TestUpdateTaskResourceAttributes(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updateTaskResourceAttributesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -54,7 +54,7 @@ func TestUpdateTaskResourceAttributes(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updateTaskResourceAttributesFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/matchable_workflow_execution_config.go
+++ b/cmd/update/matchable_workflow_execution_config.go
@@ -25,7 +25,7 @@ Example: content of wec.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 	security_context:
 	  run_as:
@@ -37,13 +37,13 @@ Example: content of wec.yaml:
 
 Update workflow execution config for project, domain, and workflow combination. This will take precedence over any other
 execution config defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     max_parallelism: 5
 	security_context:
 	  run_as:

--- a/cmd/update/matchable_workflow_execution_config_test.go
+++ b/cmd/update/matchable_workflow_execution_config_test.go
@@ -32,7 +32,7 @@ func TestWorkflowExecutionConfigs(t *testing.T) {
 			mock.Anything).Return(nil)
 		err := updateWorkflowExecutionConfigFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development`)
 	})
 	t.Run("failed update project domain attribute", func(t *testing.T) {
 		s := setup()
@@ -55,7 +55,7 @@ func TestWorkflowExecutionConfigs(t *testing.T) {
 			mock.Anything, mock.Anything).Return(nil)
 		err := updateWorkflowExecutionConfigFunc(s.Ctx, []string{}, s.CmdCtx)
 		assert.Nil(t, err)
-		tearDownAndVerify(t, s.Writer, `Updated attributes from flytectldemo project and domain development and workflow core.control_flow.run_merge_sort.merge_sort`)
+		tearDownAndVerify(t, s.Writer, `Updated attributes from flytesnacks project and domain development and workflow core.control_flow.merge_sort.merge_sort`)
 	})
 	t.Run("failed update workflow attribute", func(t *testing.T) {
 		s := setup()

--- a/cmd/update/task_meta.go
+++ b/cmd/update/task_meta.go
@@ -16,17 +16,17 @@ const (
 Update the description on the task:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --description "Merge sort example"
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --description "Merge sort example"
 
 Archiving task named entity is not supported and would throw an error:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --archive
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --archive
 
 Activating task named entity would be a noop since archiving is not possible:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --activate
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --activate
 
 Usage
 `

--- a/cmd/update/testdata/invalid_attribute.yaml
+++ b/cmd/update/testdata/invalid_attribute.yaml
@@ -1,5 +1,5 @@
 InvalidDomain: development
-InvalidProject: flytectldemo
+InvalidProject: flytesnacks
 InvalidWorkflow: ""
 cpu: "1"
 memory: 150Mi

--- a/cmd/update/testdata/valid_project_domain_cluster_attribute.yaml
+++ b/cmd/update/testdata/valid_project_domain_cluster_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 attributes:
   "foo": "bar"
   "buzz": "lightyear"

--- a/cmd/update/testdata/valid_project_domain_execution_cluster_label.yaml
+++ b/cmd/update/testdata/valid_project_domain_execution_cluster_label.yaml
@@ -1,3 +1,3 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 value: foo

--- a/cmd/update/testdata/valid_project_domain_execution_queue_attribute.yaml
+++ b/cmd/update/testdata/valid_project_domain_execution_queue_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 tags:
   - foo
   - bar

--- a/cmd/update/testdata/valid_project_domain_plugin_override.yaml
+++ b/cmd/update/testdata/valid_project_domain_plugin_override.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 overrides:
   - task_type: python_task
     plugin_id:

--- a/cmd/update/testdata/valid_project_domain_task_attribute.yaml
+++ b/cmd/update/testdata/valid_project_domain_task_attribute.yaml
@@ -1,5 +1,5 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 defaults:
   cpu: "1"
   memory: 150Mi

--- a/cmd/update/testdata/valid_project_domain_workflow_execution_config.yaml
+++ b/cmd/update/testdata/valid_project_domain_workflow_execution_config.yaml
@@ -1,3 +1,3 @@
 domain: development
-project: flytectldemo
+project: flytesnacks
 max_parallelism: 5

--- a/cmd/update/testdata/valid_workflow_cluster_attribute.yaml
+++ b/cmd/update/testdata/valid_workflow_cluster_attribute.yaml
@@ -1,6 +1,6 @@
 Domain: development
-Project: flytectldemo
-Workflow: core.control_flow.run_merge_sort.merge_sort
+Project: flytesnacks
+Workflow: core.control_flow.merge_sort.merge_sort
 attributes:
   "foo": "bar"
   "buzz": "lightyear"

--- a/cmd/update/testdata/valid_workflow_execution_cluster_label.yaml
+++ b/cmd/update/testdata/valid_workflow_execution_cluster_label.yaml
@@ -1,4 +1,4 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 value: foo

--- a/cmd/update/testdata/valid_workflow_execution_queue_attribute.yaml
+++ b/cmd/update/testdata/valid_workflow_execution_queue_attribute.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 tags:
   - foo
   - bar

--- a/cmd/update/testdata/valid_workflow_plugin_override.yaml
+++ b/cmd/update/testdata/valid_workflow_plugin_override.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 overrides:
   - task_type: python_task
     plugin_id:

--- a/cmd/update/testdata/valid_workflow_task_attribute.yaml
+++ b/cmd/update/testdata/valid_workflow_task_attribute.yaml
@@ -1,6 +1,6 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 defaults:
   cpu: "2"
   memory: 250Mi

--- a/cmd/update/testdata/valid_workflow_workflow_execution_config.yaml
+++ b/cmd/update/testdata/valid_workflow_workflow_execution_config.yaml
@@ -1,4 +1,4 @@
 domain: development
-project: flytectldemo
-workflow: core.control_flow.run_merge_sort.merge_sort
+project: flytesnacks
+workflow: core.control_flow.merge_sort.merge_sort
 max_parallelism: 5

--- a/cmd/update/workflow_meta.go
+++ b/cmd/update/workflow_meta.go
@@ -16,17 +16,17 @@ const (
 Update the description on the workflow:
 ::
 
- flytectl update workflow -p flytectldemo -d development core.advanced.run_merge_sort.merge_sort --description "Mergesort workflow example"
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
 
-Archiving workflow named entity would cause this to disapper from flyteconsole UI:
+Archiving workflow named entity would cause this to disappear from flyteconsole UI:
 ::
 
- flytectl update workflow -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --archive
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
 
 Activate workflow named entity:
 ::
 
- flytectl update workflow -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --activate
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
 
 Usage
 `

--- a/docs/source/gen/flytectl_create_execution.rst
+++ b/docs/source/gen/flytectl_create_execution.rst
@@ -17,7 +17,7 @@ There are three steps to generate an execution, as outlined below:
 1. Generate the execution spec file using the :ref:`get task <flytectl_get_task>` command.
 ::
 
-	flytectl get tasks -d development -p flytectldemo core.advanced.run_merge_sort.merge --version v2 --execFile execution_spec.yaml
+	flytectl get tasks -d development -p flytesnacks core.control_flow.merge_sort.merge --version v2 --execFile execution_spec.yaml
 
 The generated file would look similar to the following:
 
@@ -32,7 +32,7 @@ The generated file would look similar to the following:
 	kubeServiceAcct: ""
 	targetDomain: ""
 	targetProject: ""
-	task: core.advanced.run_merge_sort.merge
+	task: core.control_flow.merge_sort.merge
 	version: "v2"
 
 2. [Optional] Update the inputs for the execution, if needed.
@@ -53,7 +53,7 @@ The generated spec file can be modified to change the input values, as shown bel
 	kubeServiceAcct: ""
 	targetDomain: ""
 	targetProject: ""
-	task: core.advanced.run_merge_sort.merge
+	task: core.control_flow.merge_sort.merge
 	version: "v2"
 
 3. Run the execution by passing the generated YAML file.
@@ -67,13 +67,13 @@ To relaunch an execution, pass the current execution ID as follows:
 
 ::
 
- flytectl create execution --relaunch ffb31066a0f8b4d52b77 -p flytectldemo -d development
+ flytectl create execution --relaunch ffb31066a0f8b4d52b77 -p flytesnacks -d development
 
 To recover an execution, i.e., recreate it from the last known failure point for previously-run workflow execution, run:
 
 ::
 
- flytectl create execution --recover ffb31066a0f8b4d52b77 -p flytectldemo -d development
+ flytectl create execution --recover ffb31066a0f8b4d52b77 -p flytesnacks -d development
 
 See :ref:`ref_flyteidl.admin.ExecutionRecoverRequest` for more details.
 
@@ -82,7 +82,7 @@ The following is an example of how generic data can be specified while creating 
 
 ::
 
- flytectl get task -d development -p flytectldemo  core.type_system.custom_objects.add --execFile adddatanum.yaml
+ flytectl get task -d development -p flytesnacks  core.type_system.custom_objects.add --execFile adddatanum.yaml
 
 The generated file would look similar to this. Here, empty values have been dumped for generic data types 'x' and 'y'.
 ::

--- a/docs/source/gen/flytectl_delete_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_delete_cluster-resource-attribute.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete cluster resource attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete cluster-resource-attribute -p flytectldemo -d development
+ flytectl delete cluster-resource-attribute -p flytesnacks -d development
 
 
 To delete cluster resource attribute using the config file that was used to create it, run:
@@ -29,18 +29,18 @@ For example, here's the config file cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"
 
 Attributes are optional in the file, which are unread during the 'delete' command but can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete cluster resource attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run:
+To delete cluster resource attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run:
 
 ::
 
- flytectl delete cluster-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete cluster-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_delete_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_delete_execution-cluster-label.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete execution cluster label for a given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete execution-cluster-label -p flytectldemo -d development
+ flytectl delete execution-cluster-label -p flytesnacks -d development
 
 To delete execution cluster label using the config file that was used to create it, run:
 
@@ -28,16 +28,16 @@ For example, here's the config file ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 Value is optional in the file as it is unread during the delete command, but it can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete the execution cluster label of the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following:
+To delete the execution cluster label of the workflow 'core.control_flow.merge_sort.merge_sort', run the following:
 
 ::
 
- flytectl delete execution-cluster-label -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete execution-cluster-label -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_delete_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_delete_execution-queue-attribute.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete execution queue attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete execution-queue-attribute -p flytectldemo -d development
+ flytectl delete execution-queue-attribute -p flytesnacks -d development
 
 Delete execution queue attribute using the config file which was used to create it.
 
@@ -28,7 +28,7 @@ For example, here's the config file era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar
@@ -37,11 +37,11 @@ For example, here's the config file era.yaml:
 
 Value is optional in the file as it is unread during the delete command but it can be retained since the same file can be used for get, update and delete commands.
 
-To delete the execution queue attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete the execution queue attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete execution-queue-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete execution-queue-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_delete_plugin-override.rst
+++ b/docs/source/gen/flytectl_delete_plugin-override.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete plugin override for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete plugin-override -p flytectldemo -d development
+ flytectl delete plugin-override -p flytesnacks -d development
 
 
 To delete plugin override using the config file which was used to create it, run:
@@ -28,7 +28,7 @@ For example, here's the config file po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.
@@ -38,11 +38,11 @@ For example, here's the config file po.yaml:
 
 Overrides are optional in the file as they are unread during the delete command but can be retained since the same file can be used for get, update and delete commands.
 
-To delete plugin override for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete plugin override for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete plugin-override -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete plugin-override -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_delete_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_delete_task-resource-attribute.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete task resource attributes for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete task-resource-attribute -p flytectldemo -d development
+ flytectl delete task-resource-attribute -p flytesnacks -d development
 
 To delete task resource attribute using the config file which was used to create it, run:
 
@@ -28,7 +28,7 @@ For example, here's the config file tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"
@@ -38,11 +38,11 @@ For example, here's the config file tra.yaml:
 
 The defaults/limits are optional in the file as they are unread during the delete command, but can be retained since the same file can be used for 'get', 'update' and 'delete' commands.
 
-To delete task resource attribute for the workflow 'core.control_flow.run_merge_sort.merge_sort', run the following command:
+To delete task resource attribute for the workflow 'core.control_flow.merge_sort.merge_sort', run the following command:
 
 ::
 
- flytectl delete task-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete task-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_delete_workflow-execution-config.rst
+++ b/docs/source/gen/flytectl_delete_workflow-execution-config.rst
@@ -12,10 +12,10 @@ Synopsis
 
 Delete workflow execution config for the given project and domain combination or additionally the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl delete workflow-execution-config -p flytectldemo -d development
+ flytectl delete workflow-execution-config -p flytesnacks -d development
 
 To delete workflow execution config using the config file which was used to create it, run:
 
@@ -28,7 +28,7 @@ For example, here's the config file wec.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 	security_context:
   		run_as:
@@ -36,11 +36,11 @@ For example, here's the config file wec.yaml:
 
 Max_parallelism is optional in the file as it is unread during the delete command but can be retained since the same file can be used for get, update and delete commands.
 
-To delete workflow execution config for the workflow 'core.control_flow.run_merge_sort.merge_sort', run:
+To delete workflow execution config for the workflow 'core.control_flow.merge_sort.merge_sort', run:
 
 ::
 
- flytectl delete workflow-execution-config -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl delete workflow-execution-config -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Usage
 

--- a/docs/source/gen/flytectl_get_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_get_cluster-resource-attribute.rst
@@ -11,28 +11,28 @@ Synopsis
 
 
 Retrieve cluster resource attributes for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get cluster-resource-attribute -p flytectldemo -d development 
+ flytectl get cluster-resource-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","attributes":{"buzz":"lightyear","foo":"bar"}}
+ {"project":"flytesnacks","domain":"development","attributes":{"buzz":"lightyear","foo":"bar"}}
 
 Retrieve cluster resource attributes for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get cluster-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get cluster-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","attributes":{"buzz":"lightyear","foo":"bar"}}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","attributes":{"buzz":"lightyear","foo":"bar"}}
 
 Write the cluster resource attributes to a file. If there are no cluster resource attributes, the command throws an error.
 The config file is written to cra.yaml file.
@@ -46,7 +46,7 @@ Example: content of cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"

--- a/docs/source/gen/flytectl_get_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_get_execution-cluster-label.rst
@@ -12,28 +12,28 @@ Synopsis
 
 Retrieve the execution cluster label for a given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain, run:
+For project flytesnacks and development domain, run:
 ::
 
- flytectl get execution-cluster-label -p flytectldemo -d development 
+ flytectl get execution-cluster-label -p flytesnacks -d development
 
 The output would look like:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","value":"foo"}
+ {"project":"flytesnacks","domain":"development","value":"foo"}
 
 Retrieve the execution cluster label for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get execution-cluster-label -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get execution-cluster-label -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","value":"foo"}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","value":"foo"}
 
 Write the execution cluster label to a file. If there is no execution cluster label, the command throws an error.
 The config file is written to ecl.yaml file.
@@ -47,7 +47,7 @@ Example: content of ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 Usage

--- a/docs/source/gen/flytectl_get_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_get_execution-queue-attribute.rst
@@ -11,28 +11,28 @@ Synopsis
 
 
 Retrieve the execution queue attribute for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get execution-queue-attribute -p flytectldemo -d development 
+ flytectl get execution-queue-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","tags":["foo", "bar"]}
+ {"project":"flytesnacks","domain":"development","tags":["foo", "bar"]}
 
 Retrieve the execution queue attribute for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get execution-queue-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get execution-queue-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","tags":["foo", "bar"]}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","tags":["foo", "bar"]}
 
 Write the execution queue attribute to a file. If there are no execution queue attributes, the command throws an error.
 The config file is written to era.yaml file.
@@ -46,7 +46,7 @@ Example: content of era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar

--- a/docs/source/gen/flytectl_get_launchplan.rst
+++ b/docs/source/gen/flytectl_get_launchplan.rst
@@ -90,7 +90,7 @@ Retrieve a launch plan within the project and domain as per a version and genera
 
 ::
 
- flytectl get launchplan -d development -p flytectldemo core.advanced.run_merge_sort.merge_sort --execFile execution_spec.yaml
+ flytectl get launchplan -d development -p flytesnacks core.control_flow.merge_sort.merge_sort --execFile execution_spec.yaml
 
 The generated file would look similar to this:
 
@@ -106,7 +106,7 @@ The generated file would look similar to this:
 	 targetDomain: ""
 	 targetProject: ""
 	 version: v3
-	 workflow: core.advanced.run_merge_sort.merge_sort
+	 workflow: core.control_flow.merge_sort.merge_sort
 
 Check the :ref:`create execution section<flytectl_create_execution>` on how to launch one using the generated file.
 Usage

--- a/docs/source/gen/flytectl_get_plugin-override.rst
+++ b/docs/source/gen/flytectl_get_plugin-override.rst
@@ -11,18 +11,18 @@ Synopsis
 
 
 Retrieve the plugin override for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 
 ::
 
- flytectl get plugin-override -p flytectldemo -d development 
+ flytectl get plugin-override -p flytesnacks -d development
 
 Example: output from the command
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
 	"overrides": [{
 		"task_type": "python_task",
@@ -32,19 +32,19 @@ Example: output from the command
  }
 
 Retrieve the plugin override for the given project, domain, and workflow.
-For project flytectldemo, development domain and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get plugin-override -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get plugin-override -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
-    "workflow": "core.control_flow.run_merge_sort.merge_sort"
+    "workflow": "core.control_flow.merge_sort.merge_sort"
 	"overrides": [{
 		"task_type": "python_task",
 		"plugin_id": ["pluginoverride1", "pluginoverride2"],
@@ -64,7 +64,7 @@ Example: content of po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.

--- a/docs/source/gen/flytectl_get_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_get_task-resource-attribute.rst
@@ -11,28 +11,28 @@ Synopsis
 
 
 Retrieve task resource attributes for the given project and domain.
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 ::
 
- flytectl get task-resource-attribute -p flytectldemo -d development 
+ flytectl get task-resource-attribute -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
+ {"project":"flytesnacks","domain":"development","workflow":"","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
 
 Retrieve task resource attributes for the given project, domain, and workflow.
-For project flytectldemo, development domain, and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain, and workflow 'core.control_flow.merge_sort.merge_sort':
 ::
 
- flytectl get task-resource-attribute -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get task-resource-attribute -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
- {"project":"flytectldemo","domain":"development","workflow":"core.control_flow.run_merge_sort.merge_sort","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
+ {"project":"flytesnacks","domain":"development","workflow":"core.control_flow.merge_sort.merge_sort","defaults":{"cpu":"1","memory":"150Mi"},"limits":{"cpu":"2","memory":"450Mi"}}
 
 
 Write the task resource attributes to a file. If there are no task resource attributes, a file would be populated with the basic data.
@@ -47,7 +47,7 @@ Example: content of tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"

--- a/docs/source/gen/flytectl_get_task.rst
+++ b/docs/source/gen/flytectl_get_task.rst
@@ -72,7 +72,7 @@ Retrieve tasks within project and domain for a version and generate the executio
 
 ::
 
- flytectl get tasks -d development -p flytesnacks core.advanced.run_merge_sort.merge --execFile execution_spec.yaml --version v2
+ flytectl get tasks -d development -p flytesnacks core.control_flow.merge_sort.merge --execFile execution_spec.yaml --version v2
 
 The generated file would look similar to this:
 
@@ -87,7 +87,7 @@ The generated file would look similar to this:
 	 kubeServiceAcct: ""
 	 targetDomain: ""
 	 targetProject: ""
-	 task: core.advanced.run_merge_sort.merge
+	 task: core.control_flow.merge_sort.merge
 	 version: v2
 
 Check the create execution section on how to launch one using the generated file.

--- a/docs/source/gen/flytectl_get_workflow-execution-config.rst
+++ b/docs/source/gen/flytectl_get_workflow-execution-config.rst
@@ -12,37 +12,37 @@ Synopsis
 
 Retrieve workflow execution config for the given project and domain, in combination with the workflow name.
 
-For project flytectldemo and development domain:
+For project flytesnacks and development domain:
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development 
+ flytectl get workflow-execution-config -p flytesnacks -d development
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
 	"max_parallelism": 5
  }
 
 Retrieve workflow execution config for the project, domain, and workflow.
-For project flytectldemo, development domain and workflow 'core.control_flow.run_merge_sort.merge_sort':
+For project flytesnacks, development domain and workflow 'core.control_flow.merge_sort.merge_sort':
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development core.control_flow.run_merge_sort.merge_sort
+ flytectl get workflow-execution-config -p flytesnacks -d development core.control_flow.merge_sort.merge_sort
 
 Example: output from the command:
 
 .. code-block:: json
 
  {
-	"project": "flytectldemo",
+	"project": "flytesnacks",
 	"domain": "development",
-    "workflow": "core.control_flow.run_merge_sort.merge_sort"
+    "workflow": "core.control_flow.merge_sort.merge_sort"
 	"max_parallelism": 5
  }
 
@@ -52,13 +52,13 @@ Example: content of wec.yaml:
 
 ::
 
- flytectl get workflow-execution-config -p flytectldemo -d development --attrFile wec.yaml
+ flytectl get workflow-execution-config -p flytesnacks -d development --attrFile wec.yaml
 
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 
 Generate a sample workflow execution config file to be used for creating a new workflow execution config at project domain

--- a/docs/source/gen/flytectl_update_cluster-resource-attribute.rst
+++ b/docs/source/gen/flytectl_update_cluster-resource-attribute.rst
@@ -19,7 +19,7 @@ Example: content of cra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     attributes:
       foo: "bar"
       buzz: "lightyear"
@@ -33,13 +33,13 @@ resource attribute defined at project domain level.
 This will completely overwrite any existing custom project, domain and workflow combination attributes.
 It is preferable to do get and generate an attribute file if there is an existing attribute that is already set and then update it to have new values.
 Refer to get cluster-resource-attribute section on how to generate this file.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     attributes:
       foo: "bar"
       buzz: "lightyear"

--- a/docs/source/gen/flytectl_update_execution-cluster-label.rst
+++ b/docs/source/gen/flytectl_update_execution-cluster-label.rst
@@ -19,7 +19,7 @@ Example: content of ecl.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     value: foo
 
 ::
@@ -28,13 +28,13 @@ Example: content of ecl.yaml:
 
 Update execution cluster label for project, domain, and workflow combination. This will take precedence over any other
 execution cluster label defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     value: foo
 
 ::

--- a/docs/source/gen/flytectl_update_execution-queue-attribute.rst
+++ b/docs/source/gen/flytectl_update_execution-queue-attribute.rst
@@ -22,7 +22,7 @@ Example: content of era.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     tags:
       - foo
       - bar
@@ -35,13 +35,13 @@ Example: content of era.yaml:
 
 Update execution queue attribute for project, domain, and workflow combination. This will take precedence over any other
 execution queue attribute defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     tags:
       - foo
       - bar

--- a/docs/source/gen/flytectl_update_execution.rst
+++ b/docs/source/gen/flytectl_update_execution.rst
@@ -13,12 +13,12 @@ Synopsis
 Activate an execution; and it shows up in the CLI and UI:
 ::
 
- flytectl update execution -p flytectldemo -d development  oeh94k9r2r --activate
+ flytectl update execution -p flytesnacks -d development  oeh94k9r2r --activate
 
 Archive an execution; and it is hidden from the CLI and UI:
 ::
 
- flytectl update execution -p flytectldemo -d development  oeh94k9r2r --archive
+ flytectl update execution -p flytesnacks -d development  oeh94k9r2r --archive
 
 
 Usage

--- a/docs/source/gen/flytectl_update_launchplan-meta.rst
+++ b/docs/source/gen/flytectl_update_launchplan-meta.rst
@@ -13,17 +13,17 @@ Synopsis
 Update the description on the launch plan:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --description "Mergesort example"
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort example"
 
 Archiving launch plan named entity is not supported and would throw an error:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --archive
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
 
 Activating launch plan named entity would be a noop:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --activate
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
 
 Usage
 

--- a/docs/source/gen/flytectl_update_launchplan.rst
+++ b/docs/source/gen/flytectl_update_launchplan.rst
@@ -13,12 +13,12 @@ Synopsis
 Activates a launch plan which activates the scheduled job associated with it:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --version v1 --activate
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --activate
 
 Archives a launch plan which deschedules any scheduled job associated with it:
 ::
 
- flytectl update launchplan -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --version v1 --archive
+ flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --archive
 
 
 Usage

--- a/docs/source/gen/flytectl_update_plugin-override.rst
+++ b/docs/source/gen/flytectl_update_plugin-override.rst
@@ -22,7 +22,7 @@ Example: content of po.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.
@@ -36,13 +36,13 @@ Example: content of po.yaml:
 
 Update plugin override for project, domain, and workflow combination. This will take precedence over any other
 plugin overrides defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     overrides:
        - task_type: python_task # Task type for which to apply plugin implementation overrides
          plugin_id:             # Plugin id(s) to be used in place of the default for the task type.

--- a/docs/source/gen/flytectl_update_task-meta.rst
+++ b/docs/source/gen/flytectl_update_task-meta.rst
@@ -13,17 +13,17 @@ Synopsis
 Update the description on the task:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --description "Merge sort example"
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --description "Merge sort example"
 
 Archiving task named entity is not supported and would throw an error:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --archive
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --archive
 
 Activating task named entity would be a noop since archiving is not possible:
 ::
 
- flytectl update  task -d development -p flytectldemo core.advanced.run_merge_sort.merge --activate
+ flytectl update  task -d development -p flytesnacks core.control_flow.merge_sort.merge --activate
 
 Usage
 

--- a/docs/source/gen/flytectl_update_task-resource-attribute.rst
+++ b/docs/source/gen/flytectl_update_task-resource-attribute.rst
@@ -22,7 +22,7 @@ Example: content of tra.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     defaults:
       cpu: "1"
       memory: "150Mi"
@@ -36,13 +36,13 @@ Example: content of tra.yaml:
 
 Update task resource attribute for project, domain, and workflow combination. This will take precedence over any other
 resource attribute defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     defaults:
       cpu: "1"
       memory: "150Mi"

--- a/docs/source/gen/flytectl_update_workflow-execution-config.rst
+++ b/docs/source/gen/flytectl_update_workflow-execution-config.rst
@@ -22,7 +22,7 @@ Example: content of wec.yaml:
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
+    project: flytesnacks
     max_parallelism: 5
 	security_context:
 	  run_as:
@@ -34,13 +34,13 @@ Example: content of wec.yaml:
 
 Update workflow execution config for project, domain, and workflow combination. This will take precedence over any other
 execution config defined at project domain level.
-For workflow 'core.control_flow.run_merge_sort.merge_sort' in flytectldemo project, development domain, it is:
+For workflow 'core.control_flow.merge_sort.merge_sort' in flytesnacks project, development domain, it is:
 
 .. code-block:: yaml
 
     domain: development
-    project: flytectldemo
-    workflow: core.control_flow.run_merge_sort.merge_sort
+    project: flytesnacks
+    workflow: core.control_flow.merge_sort.merge_sort
     max_parallelism: 5
 	security_context:
 	  run_as:

--- a/docs/source/gen/flytectl_update_workflow-meta.rst
+++ b/docs/source/gen/flytectl_update_workflow-meta.rst
@@ -13,17 +13,17 @@ Synopsis
 Update the description on the workflow:
 ::
 
- flytectl update workflow -p flytectldemo -d development core.advanced.run_merge_sort.merge_sort --description "Mergesort workflow example"
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
 
-Archiving workflow named entity would cause this to disapper from flyteconsole UI:
+Archiving workflow named entity would cause this to disappear from flyteconsole UI:
 ::
 
- flytectl update workflow -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --archive
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
 
 Activate workflow named entity:
 ::
 
- flytectl update workflow -p flytectldemo -d development  core.advanced.run_merge_sort.merge_sort --activate
+ flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
 
 Usage
 


### PR DESCRIPTION

## Read then delete

- Make sure to use a concise title for the pull-request.
- Use #patch, #minor #majora or #none in the pull-request title to bump the corresponding version. Otherwise, the patch version
  will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)

# TL;DR

It seems that flytectl no longer register examples to a `flytectldemo`
project, rather, the project name should be `flytesnacks`.

And, the workflow name `core.advanced.run_merge_sort.merge_sort` and
`core.control_flow.run_merge_sort.merge_sort` should be `core.control_flow.merge_sort.merge_sort`.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description

- Update the project name and workflow name.

## Tracking Issue

N/A

## Follow-up issue
_NA_
