### PR TITLE
Fix "Sandbox" typo on Demo page.

### DIFF
--- a/docs/source/demo.rst
+++ b/docs/source/demo.rst
@@ -1,10 +1,10 @@
-Sandbox
+Demo
 -------
-It specifies the actions to be performed on the 'demo' resource. 
+These are the actions which can be performed on the 'demo' resource. 
 
 .. toctree::
     :maxdepth: 1
-    :caption: Sandbox
+    :caption: Demo
 
     gen/flytectl_demo_start
     gen/flytectl_demo_status


### PR DESCRIPTION
# TL;DR
Documentation fix: the `flyectl demo` docs page currently talks about the sandbox:
![CleanShot 2022-08-18 at 10 48 47](https://user-images.githubusercontent.com/151841/185353081-c82654ef-eb01-49d7-b4df-f3844cbb375e.png)


## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin
- [x] Documentation

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

