### PR TITLE
update launch_plan.go

### DIFF
--- a/cmd/get/launch_plan.go
+++ b/cmd/get/launch_plan.go
@@ -23,9 +23,10 @@ Retrieve all launch plans within the project and domain:
  flytectl get launchplan -p flytesnacks -d development
 
 .. note::
-     The terms launchplan/launchplans are interchangeable in these commands.
+    
+   The terms launchplan/launchplans are interchangeable in these commands.
 
- Retrieve a launch plan by name within the project and domain:
+Retrieve a launch plan by name within the project and domain:
 
 ::
 

--- a/cmd/update/launch_plan.go
+++ b/cmd/update/launch_plan.go
@@ -16,16 +16,15 @@ import (
 const (
 	updateLPShort = "Updates launch plan status"
 	updateLPLong  = `
-Activates a launch plan which activates the scheduled job associated with it:
+Activates a ` + "`launch plan <https://docs.flyte.org/projects/cookbook/en/latest/auto/core/scheduled_workflows/lp_schedules.html#activating-a-schedule>`__" + ` which activates the scheduled job associated with it:
 ::
 
  flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --activate
 
-Archives (deactivates) a launch plan which deschedules any scheduled job associated with it:
+Archives ` + "`(deactivates) <https://docs.flyte.org/projects/cookbook/en/latest/auto/core/scheduled_workflows/lp_schedules.html#deactivating-a-schedule>`__" + ` a launch plan which deschedules any scheduled job associated with it:
 ::
 
  flytectl update launchplan -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --version v1 --archive
-
 
 Usage
 `


### PR DESCRIPTION
add links to activating and deactivating a launch plan
Signed-off-by: SmritiSatyanV smriti@union.ai
[Slack conversation](https://flyte-org.slack.com/archives/CP2HDHKE1/p1663571417467739)

``Synopsis:
User: It might be good to link to the activating/deactivating a LaunchPlanSpec page from the API ref page since there is no way to find it from launch plans pages currently.``