### PR TITLE
Fix link formatting in contributing guide

### DIFF
--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -8,7 +8,7 @@ Here are the instructions that will guide you through contributing, fixing, and 
 📝 Contribute to Documentation
 ==============================
 
-Docs are generated using Sphinx and are available at [flytectl.rtfd.io](https://flytectl.rtfd.io).
+Docs are generated using Sphinx and are available at `flytectl.rtfd.io <https://flytectl.rtfd.io>`__.
 
 To update the documentation, follow these steps:
 


### PR DESCRIPTION
# TL;DR
Fix link formatting contributing guide.

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin
- [x] Documentation

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [x] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Fixed the first link to flytectl.rtfd.io in the contributing guide.
https://docs.flyte.org/projects/flytectl/en/latest/contribute.html#contribute-to-documentation