### PR TITLE
Fix --clusterPool argument override

### DIFF
--- a/cmd/create/execution_util.go
+++ b/cmd/create/execution_util.go
@@ -201,6 +201,9 @@ func resolveOverrides(toBeOverridden *ExecutionConfig, project string, domain st
 	if executionConfig.Version != "" {
 		toBeOverridden.Version = executionConfig.Version
 	}
+	if executionConfig.ClusterPool != "" {
+		toBeOverridden.ClusterPool = executionConfig.ClusterPool
+	}
 	// Use the root project and domain to launch the task/workflow if target is unspecified
 	if executionConfig.TargetProject == "" {
 		toBeOverridden.TargetProject = project

--- a/cmd/create/execution_util_test.go
+++ b/cmd/create/execution_util_test.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+
+	"github.com/flyteorg/flytectl/cmd/config"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -191,4 +192,23 @@ func TestCreateExecutionRequestForTask(t *testing.T) {
 		assert.NotNil(t, execCreateRequest)
 		executionConfig.KubeServiceAcct = ""
 	})
+}
+
+func Test_resolveOverrides(t *testing.T) {
+	executionConfig.KubeServiceAcct = "k8s-acct"
+	executionConfig.IamRoleARN = "iam-role"
+	executionConfig.TargetProject = "t-proj"
+	executionConfig.TargetDomain = "t-domain"
+	executionConfig.Version = "v1"
+	executionConfig.ClusterPool = "gpu"
+	cfg := &ExecutionConfig{}
+
+	resolveOverrides(cfg, "p1", "d1")
+
+	assert.Equal(t, "k8s-acct", cfg.KubeServiceAcct)
+	assert.Equal(t, "iam-role", cfg.IamRoleARN)
+	assert.Equal(t, "t-proj", cfg.TargetProject)
+	assert.Equal(t, "t-domain", cfg.TargetDomain)
+	assert.Equal(t, "v1", cfg.Version)
+	assert.Equal(t, "gpu", cfg.ClusterPool)
 }


### PR DESCRIPTION
Signed-off-by: Iaroslav Ciupin <iaroslav@union.ai>

# TL;DR
Fix `--clusterPool` argument when creating new execution

Fixes https://github.com/unionai/cloud/issues/843

## Type
- [x] Bug Fix

