### PR TITLE
Check kubeConfig before starting sandbox #minor

### DIFF
--- a/pkg/k8s/k8s.go
+++ b/pkg/k8s/k8s.go
@@ -17,6 +17,7 @@ type K8s interface {
 
 //go:generate mockery -name=ContextOps -case=underscore
 type ContextOps interface {
+	CheckConfig() error
 	CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName, targetCtxName string) error
 	RemoveContext(ctxName string) error
 }
@@ -56,9 +57,15 @@ func GetK8sClient(cfg, master string) (K8s, error) {
 	return Client, nil
 }
 
+// CheckConfig checks if the kubeConfig pointed to by configAccess exists
+func (k *ContextManager) CheckConfig() error {
+	_, err := k.configAccess.GetStartingConfig()
+	return err
+}
+
 // CopyKubeContext copies context srcCtxName part of srcConfigAccess to targetCtxName part of targetConfigAccess.
 func (k *ContextManager) CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName, targetCtxName string) error {
-	_, err := k.configAccess.GetStartingConfig()
+	err := k.CheckConfig()
 	if err != nil {
 		return err
 	}

--- a/pkg/k8s/mocks/context_ops.go
+++ b/pkg/k8s/mocks/context_ops.go
@@ -13,6 +13,38 @@ type ContextOps struct {
 	mock.Mock
 }
 
+type ContextOps_CheckConfig struct {
+	*mock.Call
+}
+
+func (_m ContextOps_CheckConfig) Return(_a0 error) *ContextOps_CheckConfig {
+	return &ContextOps_CheckConfig{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *ContextOps) OnCheckConfig() *ContextOps_CheckConfig {
+	c_call := _m.On("CheckConfig")
+	return &ContextOps_CheckConfig{Call: c_call}
+}
+
+func (_m *ContextOps) OnCheckConfigMatch(matchers ...interface{}) *ContextOps_CheckConfig {
+	c_call := _m.On("CheckConfig", matchers...)
+	return &ContextOps_CheckConfig{Call: c_call}
+}
+
+// CheckConfig provides a mock function with given fields:
+func (_m *ContextOps) CheckConfig() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type ContextOps_CopyContext struct {
 	*mock.Call
 }

--- a/pkg/sandbox/start_test.go
+++ b/pkg/sandbox/start_test.go
@@ -310,6 +310,7 @@ func TestStartFunc(t *testing.T) {
 		sandboxCmdConfig.DefaultConfig.Version = ""
 		k8s.ContextMgr = mockK8sContextMgr
 		ghutil.Client = githubMock
+		mockK8sContextMgr.OnCheckConfig().Return(nil)
 		mockK8sContextMgr.OnCopyContextMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		err = StartSandboxCluster(context.Background(), []string{}, config)
 		assert.Nil(t, err)


### PR DESCRIPTION
# TL;DR
Adds a pre-check to verify if the local kubeconfig exists before starting the sandbox so that it fails-fast if the kubeconfig doesn't exist, instead of failing when trying to copy the sandbox context to the local kubecontext.

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [x] Any pending items have an associated Issue

## Complete description
Abstracted out the check from `ContextOps#CopyContext()` to a new `ContextOps#CheckConfig()` function. `StartCluster()` would then instantiate a new `ContextManager` and call `ContextManager#CheckConfig()` before starting the sandbox.

This required re-generating `pkg/k8s/mocks/context_ops.go` using `mockery`.
Running the latest version (`2.x.x`) of [mockery](https://github.com/vektra/mockery) with `mockery -name=ContextOps -case=underscore` fails because the `-name` option has been changed to `-n`/`--name`. Running with a `1.x.x` version of [mockery](https://github.com/vektra/mockery) fails with:
```
package "fmt" without types was imported from ... without types
```
Eventually I discovered that `flytectl` uses a fork of `mockery` (https://github.com/EngHabu/mockery), and that I could run [make generate](https://github.com/flyteorg/flytectl/blob/v0.6.18/boilerplate/flyte/golang_test_targets/Makefile#L11-L13) to install and run it. This really should be documented in the contribution guide (`docs/source/contribute.rst`).

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2943

## Follow-up issue
_NA_
