### PR TITLE
Share demo/sandbox status command logic

### DIFF
--- a/cmd/demo/status.go
+++ b/cmd/demo/status.go
@@ -2,9 +2,9 @@ package demo
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/enescakir/emoji"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
+
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/docker"
 )
@@ -28,18 +28,5 @@ func demoClusterStatus(ctx context.Context, args []string, cmdCtx cmdCore.Comman
 		return err
 	}
 
-	return printStatus(ctx, cli)
-}
-
-func printStatus(ctx context.Context, cli docker.Docker) error {
-	c, err := docker.GetSandbox(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if c == nil {
-		fmt.Printf("%v no demo cluster found \n", emoji.StopSign)
-		return nil
-	}
-	fmt.Printf("Flyte demo cluster container image [%s] with status [%s] is in state [%s]", c.Image, c.Status, c.State)
-	return nil
+	return sandbox.PrintStatus(ctx, cli)
 }

--- a/cmd/sandbox/status.go
+++ b/cmd/sandbox/status.go
@@ -2,9 +2,9 @@ package sandbox
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/enescakir/emoji"
+	"github.com/flyteorg/flytectl/pkg/sandbox"
+
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/docker"
 )
@@ -28,18 +28,5 @@ func sandboxClusterStatus(ctx context.Context, args []string, cmdCtx cmdCore.Com
 		return err
 	}
 
-	return printStatus(ctx, cli)
-}
-
-func printStatus(ctx context.Context, cli docker.Docker) error {
-	c, err := docker.GetSandbox(ctx, cli)
-	if err != nil {
-		return err
-	}
-	if c == nil {
-		fmt.Printf("%v no Sandbox found \n", emoji.StopSign)
-		return nil
-	}
-	fmt.Printf("Flyte local sandbox cluster container image [%s] with status [%s] is in state [%s]", c.Image, c.Status, c.State)
-	return nil
+	return sandbox.PrintStatus(ctx, cli)
 }

--- a/pkg/sandbox/status.go
+++ b/pkg/sandbox/status.go
@@ -1,0 +1,22 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/enescakir/emoji"
+	"github.com/flyteorg/flytectl/pkg/docker"
+)
+
+func PrintStatus(ctx context.Context, cli docker.Docker) error {
+	c, err := docker.GetSandbox(ctx, cli)
+	if err != nil {
+		return err
+	}
+	if c == nil {
+		fmt.Printf("%v no Sandbox found \n", emoji.StopSign)
+		return nil
+	}
+	fmt.Printf("Flyte local sandbox container image [%s] with status [%s] is in state [%s]", c.Image, c.Status, c.State)
+	return nil
+}

--- a/pkg/sandbox/status_test.go
+++ b/pkg/sandbox/status_test.go
@@ -1,0 +1,37 @@
+package sandbox
+
+import (
+	"testing"
+
+	"github.com/flyteorg/flytectl/cmd/testutils"
+
+	"github.com/docker/docker/api/types"
+	"github.com/flyteorg/flytectl/pkg/docker"
+	"github.com/flyteorg/flytectl/pkg/docker/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSandboxStatus(t *testing.T) {
+	t.Run("Sandbox status with zero result", func(t *testing.T) {
+		mockDocker := &mocks.Docker{}
+		s := testutils.Setup()
+		mockDocker.OnContainerList(s.Ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
+		err := PrintStatus(s.Ctx, mockDocker)
+		assert.Nil(t, err)
+	})
+	t.Run("Sandbox status with running sandbox", func(t *testing.T) {
+		s := testutils.Setup()
+		ctx := s.Ctx
+		mockDocker := &mocks.Docker{}
+		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{
+			{
+				ID: docker.FlyteSandboxClusterName,
+				Names: []string{
+					docker.FlyteSandboxClusterName,
+				},
+			},
+		}, nil)
+		err := PrintStatus(ctx, mockDocker)
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
# TL;DR
Refactor `flytectl demo status` and `flytectl sandbox status` commands to reuse the same logic.

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [x] Code documentation added
- [x] Any pending items have an associated Issue

## Complete description
Move shared logic to `pkg/sandbox/status.go`.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2472

## Follow-up issue
_NA_
