### PR TITLE
Do not fail on unit test failures [temporary fix]

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,11 +24,12 @@ jobs:
 
   tests:
     name: Unit Tests
-    uses: flyteorg/flytetools/.github/workflows/tests.yml@code-cov-3.1
+    uses: flyteorg/flytetools/.github/workflows/tests.yml@master
     secrets:
       FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
     with:
       go-version: 1.18
+      fail_ci_if_error: false
 
   generate:
     name: Check Go Gennerate

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ jobs:
 
   tests:
     name: Unit Tests
-    uses: flyteorg/flytetools/.github/workflows/tests.yml@master
+    uses: flyteorg/flytetools/.github/workflows/tests.yml@code-cov-3.1
     secrets:
       FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
     with:


### PR DESCRIPTION
# TL;DR
Temporary change to make a release.

Unit tests themselves are fine.  But the pushing of code cov results keeps failing.  We're using an old version of the codecov action even though we've already [updated](https://github.com/flyteorg/flytetools/pull/68/files) the version.

https://github.com/flyteorg/flytectl/actions/runs/3481963947
https://github.com/flyteorg/flytectl/actions/runs/3482336168/jobs/5826531245
