### PR TITLE
Remove unused root command arg from upgrade command

### DIFF
--- a/cmd/core/cmd.go
+++ b/cmd/core/cmd.go
@@ -30,22 +30,26 @@ type CommandEntry struct {
 	DisableFlyteClient       bool
 }
 
+func ToCobraCommand(resource string, cmdEntry CommandEntry) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          resource,
+		Short:        cmdEntry.Short,
+		Long:         cmdEntry.Long,
+		Aliases:      cmdEntry.Aliases,
+		RunE:         generateCommandFunc(cmdEntry),
+		SilenceUsage: true,
+	}
+
+	if cmdEntry.PFlagProvider != nil {
+		cmd.Flags().AddFlagSet(cmdEntry.PFlagProvider.GetPFlagSet(""))
+	}
+
+	return cmd
+}
+
 func AddCommands(rootCmd *cobra.Command, cmdFuncs map[string]CommandEntry) {
 	for resource, cmdEntry := range cmdFuncs {
-		cmd := &cobra.Command{
-			Use:          resource,
-			Short:        cmdEntry.Short,
-			Long:         cmdEntry.Long,
-			Aliases:      cmdEntry.Aliases,
-			RunE:         generateCommandFunc(cmdEntry),
-			SilenceUsage: true,
-		}
-
-		if cmdEntry.PFlagProvider != nil {
-			cmd.Flags().AddFlagSet(cmdEntry.PFlagProvider.GetPFlagSet(""))
-		}
-
-		rootCmd.AddCommand(cmd)
+		rootCmd.AddCommand(ToCobraCommand(resource, cmdEntry))
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,7 +73,7 @@ func newRootCmd() *cobra.Command {
 	cmdCore.AddCommands(rootCmd, versionCmd)
 
 	// Added upgrade command
-	upgradeCmd := upgrade.SelfUpgrade(rootCmd)
+	upgradeCmd := upgrade.SelfUpgrade()
 	cmdCore.AddCommands(rootCmd, upgradeCmd)
 
 	config.GetConfig()

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -19,7 +19,6 @@ import (
 
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytectl/pkg/platformutil"
-	"github.com/spf13/cobra"
 )
 
 type Goos string
@@ -52,7 +51,7 @@ var (
 )
 
 // SelfUpgrade will return self upgrade command
-func SelfUpgrade(rootCmd *cobra.Command) map[string]cmdCore.CommandEntry {
+func SelfUpgrade() map[string]cmdCore.CommandEntry {
 	getResourcesFuncs := map[string]cmdCore.CommandEntry{
 		"upgrade": {
 			CmdFunc:                  selfUpgrade,

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -30,7 +30,7 @@ func TestUpgradeCommand(t *testing.T) {
 		Use:               "flytectl",
 		DisableAutoGenTag: true,
 	}
-	upgradeCmd := SelfUpgrade(rootCmd)
+	upgradeCmd := SelfUpgrade()
 	cmdCore.AddCommands(rootCmd, upgradeCmd)
 	assert.Equal(t, len(rootCmd.Commands()), 1)
 	cmdNouns := rootCmd.Commands()


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

## Read then delete

# TL;DR
Update the upgrade command to remove an unused variable.

Also adds a package-exported transformer for flytectl CommandEntry -> Cobra commands

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin
- [ ] Housekeeping

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_NA_

## Follow-up issue
_NA_
