### PR TITLE
Recognize windows arm as a valid OS+arch combination

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,7 @@ get_binaries() {
     linux/arm64) BINARIES="flytectl" ;;
     windows/386) BINARIES="flytectl" ;;
     windows/amd64) BINARIES="flytectl" ;;
+    windows/arm64) BINARIES="flytectl" ;;
     *)
       log_crit "platform $PLATFORM is not supported.  Make sure this script is up-to-date and file request at https://github.com/${PREFIX}/issues/new"
       exit 1


### PR DESCRIPTION
Signed-off-by: Eduardo Apolinario <eapolinario@users.noreply.github.com>

# TL;DR
windows arm machines are a reality and should be recognized in the install script

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3290

## Follow-up issue
_NA_
