### PR TITLE
Fix docs for updating description using workflow-meta subcommand

### DIFF
--- a/cmd/update/workflow_meta.go
+++ b/cmd/update/workflow_meta.go
@@ -16,17 +16,17 @@ const (
 Update the description on the workflow:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
 
 Archiving workflow named entity would cause this to disappear from flyteconsole UI:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
 
 Activate workflow named entity:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
 
 Usage
 `

--- a/docs/source/gen/flytectl_update_workflow-meta.rst
+++ b/docs/source/gen/flytectl_update_workflow-meta.rst
@@ -13,17 +13,17 @@ Synopsis
 Update the description on the workflow:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --description "Mergesort workflow example"
 
 Archiving workflow named entity would cause this to disappear from flyteconsole UI:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --archive
 
 Activate workflow named entity:
 ::
 
- flytectl update workflow -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
+ flytectl update workflow-meta -p flytesnacks -d development core.control_flow.merge_sort.merge_sort --activate
 
 Usage
 


### PR DESCRIPTION
# TL;DR
The subcommand (`flytectl update workflow`) in docs doesn't exist and should be `workflow-meta` instead.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
