### PR TITLE
Remove go as dependency of brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,6 +84,3 @@ brews:
 
     # Default is false.
     skip_upload: auto
-
-    dependencies:
-    - name: go


### PR DESCRIPTION
# TL;DR
Remove go as dependency of brew formula

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Since we are pulling the built binary, `go` shouldn't be needed.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/3406

## Follow-up issue
_NA_
