### PR TITLE
Fix flyteadmin port in `flytectl config init`

### DIFF
--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -85,7 +85,7 @@ func initFlytectlConfig(reader io.Reader) error {
 	}
 
 	templateValues := configutil.ConfigTemplateSpec{
-		Host:     "dns:///localhost:30081",
+		Host:     "dns:///localhost:30080",
 		Insecure: true,
 	}
 	templateStr := configutil.GetTemplate()


### PR DESCRIPTION
# TL;DR
Fix the flyteadmin port by `flytectl config init` to match the one required by demo cluster

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
