### PR TITLE
Respect project state in project.yaml file

### DIFF
--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -68,6 +68,11 @@ func (c *ConfigProject) GetProjectSpec(id string) (*admin.Project, error) {
 	projectSpec.Labels = &admin.Labels{
 		Values: c.Labels,
 	}
+	projectState, err := c.MapToAdminState()
+	if err != nil {
+		return nil, err
+	}
+	projectSpec.State = projectState
 	return &projectSpec, nil
 }
 

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -88,7 +88,6 @@ func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comma
 	if err != nil {
 		return err
 	}
-	logger.Infof(ctx, "projectSpec from file: [%+v]", projectSpec)
 	if projectSpec.Id == "" {
 		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -88,15 +88,11 @@ func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comma
 	if err != nil {
 		return err
 	}
+	logger.Infof(ctx, "projectSpec from file: [%+v]", projectSpec)
 	if projectSpec.Id == "" {
 		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}
 
-	state, err := project.DefaultProjectConfig.MapToAdminState()
-	if err != nil {
-		return err
-	}
-	projectSpec.State = state
 	if project.DefaultProjectConfig.DryRun {
 		logger.Infof(ctx, "skipping UpdateProject request (dryRun)")
 	} else {

--- a/cmd/update/project_test.go
+++ b/cmd/update/project_test.go
@@ -27,9 +27,11 @@ func updateProjectSetup() {
 	}
 }
 
-func modifyProjectFlags(archiveProject *bool, newArchiveVal bool, activateProject *bool, newActivateVal bool) {
-	*archiveProject = newArchiveVal
-	*activateProject = newActivateVal
+func modifyProjectFlags(newArchiveVal bool, newActivateVal bool) {
+	project.DefaultProjectConfig.ArchiveProject = newArchiveVal
+	project.DefaultProjectConfig.Archive = newArchiveVal
+	project.DefaultProjectConfig.ActivateProject = newActivateVal
+	project.DefaultProjectConfig.Activate = newActivateVal
 }
 
 func TestActivateProjectFunc(t *testing.T) {
@@ -37,7 +39,7 @@ func TestActivateProjectFunc(t *testing.T) {
 	updateProjectSetup()
 	config.GetConfig().Project = projectValue
 	project.DefaultProjectConfig.Name = projectValue
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), false, &(project.DefaultProjectConfig.ActivateProject), true)
+	modifyProjectFlags(false, true)
 	projectUpdateRequest = &admin.Project{
 		Id:   projectValue,
 		Name: projectValue,
@@ -58,7 +60,7 @@ func TestActivateProjectFuncWithError(t *testing.T) {
 	updateProjectSetup()
 	config.GetConfig().Project = projectValue
 	project.DefaultProjectConfig.Name = projectValue
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), false, &(project.DefaultProjectConfig.ActivateProject), true)
+	modifyProjectFlags(false, true)
 	projectUpdateRequest = &admin.Project{
 		Id:   projectValue,
 		Name: projectValue,
@@ -80,7 +82,7 @@ func TestArchiveProjectFunc(t *testing.T) {
 	config.GetConfig().Project = projectValue
 	project.DefaultProjectConfig = &project.ConfigProject{}
 	project.DefaultProjectConfig.Name = projectValue
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), true, &(project.DefaultProjectConfig.ActivateProject), false)
+	modifyProjectFlags(true, false)
 	projectUpdateRequest = &admin.Project{
 		Id:   projectValue,
 		Name: projectValue,
@@ -101,7 +103,7 @@ func TestArchiveProjectFuncWithError(t *testing.T) {
 	updateProjectSetup()
 	project.DefaultProjectConfig.Name = projectValue
 	project.DefaultProjectConfig.Labels = map[string]string{}
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), true, &(project.DefaultProjectConfig.ActivateProject), false)
+	modifyProjectFlags(true, false)
 	projectUpdateRequest = &admin.Project{
 		Id:   projectValue,
 		Name: projectValue,
@@ -122,7 +124,7 @@ func TestEmptyProjectInput(t *testing.T) {
 	s := setup()
 	updateProjectSetup()
 	config.GetConfig().Project = ""
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), false, &(project.DefaultProjectConfig.ActivateProject), true)
+	modifyProjectFlags(false, true)
 	err := updateProjectsFunc(s.Ctx, []string{}, s.CmdCtx)
 	assert.NotNil(t, err)
 	assert.Equal(t, fmt.Errorf(clierrors.ErrProjectNotPassed), err)
@@ -133,7 +135,7 @@ func TestInvalidInput(t *testing.T) {
 	updateProjectSetup()
 	config.GetConfig().Project = projectValue
 	project.DefaultProjectConfig.Name = projectValue
-	modifyProjectFlags(&(project.DefaultProjectConfig.ArchiveProject), true, &(project.DefaultProjectConfig.ActivateProject), true)
+	modifyProjectFlags(true, true)
 	err := updateProjectsFunc(s.Ctx, []string{}, s.CmdCtx)
 	assert.NotNil(t, err)
 	assert.Equal(t, fmt.Errorf(clierrors.ErrInvalidStateUpdate), err)


### PR DESCRIPTION
# TL;DR
Project state specified in a project.yaml file is always overridden by the default config flag currently.

This change updates project.yaml parsing to respect the state defined in the project.yaml file and only read from the config value when no project.yaml is defined.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Testing:

- Tested by setting `state: 1` and then `state: 0` in project.yaml and verified the project was archived and activated as expected (see https://github.com/flyteorg/flyteidl/blob/master/protos/flyteidl/admin/project.proto#L37,L45 for enum values)
- Also used command line flags ` flytectl update project -p flytetester --archiveProject` and then `flytectl update project -p flytetester --activate` to verify the project archived and activated as expected

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3605

## Follow-up issue
_NA_
