### PR TITLE
Print instruction after teardown

### DIFF
--- a/doc-requirements.in
+++ b/doc-requirements.in
@@ -5,5 +5,5 @@ sphinx-material
 sphinx-code-include
 sphinx-copybutton
 sphinx_fontawesome
-sphinxcontrib-yt
+sphinxcontrib-youtube
 sphinx-panels

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -90,7 +90,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sphinxcontrib-yt==0.2.2
+sphinxcontrib-youtube==1.2.0
     # via -r doc-requirements.in
 text-unidecode==1.3
     # via python-slugify

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "sphinx-prompt",
     "sphinx_copybutton",
     "sphinx_fontawesome",
-    "sphinxcontrib-youtube",
+    "sphinxcontrib.youtube",
     "sphinx_panels",
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     "sphinx-prompt",
     "sphinx_copybutton",
     "sphinx_fontawesome",
-    "sphinxcontrib.yt",
+    "sphinxcontrib-youtube",
     "sphinx_panels",
 ]
 

--- a/pkg/sandbox/start.go
+++ b/pkg/sandbox/start.go
@@ -162,7 +162,7 @@ func startSandbox(ctx context.Context, cli docker.Docker, g github.GHRepoService
 				return nil, err
 			}
 			fmt.Printf("Existing details of your sandbox")
-			util.PrintSandboxMessage(consolePort, docker.Kubeconfig, sandboxConfig.DryRun)
+			util.PrintSandboxStartMessage(consolePort, docker.Kubeconfig, sandboxConfig.DryRun)
 			return nil, nil
 		}
 	}
@@ -429,7 +429,7 @@ func StartDemoCluster(ctx context.Context, args []string, sandboxConfig *sandbox
 	if err != nil {
 		return err
 	}
-	util.PrintDemoMessage(util.DemoConsolePort, docker.Kubeconfig, sandboxConfig.DryRun)
+	util.PrintDemoStartMessage(util.DemoConsolePort, docker.Kubeconfig, sandboxConfig.DryRun)
 	return nil
 }
 
@@ -444,6 +444,6 @@ func StartSandboxCluster(ctx context.Context, args []string, sandboxConfig *sand
 	if err != nil {
 		return err
 	}
-	util.PrintSandboxMessage(util.SandBoxConsolePort, docker.SandboxKubeconfig, sandboxConfig.DryRun)
+	util.PrintSandboxStartMessage(util.SandBoxConsolePort, docker.SandboxKubeconfig, sandboxConfig.DryRun)
 	return nil
 }

--- a/pkg/sandbox/teardown.go
+++ b/pkg/sandbox/teardown.go
@@ -3,7 +3,6 @@ package sandbox
 import (
 	"context"
 	"fmt"
-	"github.com/flyteorg/flytectl/pkg/util"
 
 	"github.com/docker/docker/api/types"
 	"github.com/enescakir/emoji"
@@ -11,6 +10,7 @@ import (
 	"github.com/flyteorg/flytectl/pkg/configutil"
 	"github.com/flyteorg/flytectl/pkg/docker"
 	"github.com/flyteorg/flytectl/pkg/k8s"
+	"github.com/flyteorg/flytectl/pkg/util"
 )
 
 func Teardown(ctx context.Context, cli docker.Docker, teardownFlags *sandboxCmdConfig.TeardownFlags) error {

--- a/pkg/sandbox/teardown.go
+++ b/pkg/sandbox/teardown.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"github.com/flyteorg/flytectl/pkg/util"
 
 	"github.com/docker/docker/api/types"
 	"github.com/enescakir/emoji"
@@ -38,6 +39,7 @@ func Teardown(ctx context.Context, cli docker.Docker, teardownFlags *sandboxCmdC
 	}
 
 	fmt.Printf("%v %v Sandbox cluster is removed successfully.\n", emoji.Broom, emoji.Broom)
+	util.PrintSandboxTeardownMessage(util.SandBoxConsolePort, docker.SandboxKubeconfig)
 	return nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -72,12 +72,6 @@ func SetupFlyteDir() error {
 	return nil
 }
 
-// PrintDemoMessage will print demo start success message
-// Deprecated: use PrintDemoStartMessage
-func PrintDemoMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
-	PrintDemoStartMessage(flyteConsolePort, kubeconfigLocation, dryRun)
-}
-
 // PrintDemoStartMessage will print demo start success message
 func PrintDemoStartMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
 	kubeconfig := strings.Join([]string{
@@ -100,12 +94,6 @@ func PrintDemoStartMessage(flyteConsolePort int, kubeconfigLocation string, dryR
 	}
 	fmt.Printf("%s Flyte sandbox ships with a Docker registry. Tag and push custom workflow images to localhost:30000\n", emoji.Whale)
 	fmt.Printf("%s The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console\n", emoji.OpenFileFolder)
-}
-
-// PrintSandboxMessage will print sandbox start success message
-// Deprecated: use PrintSandboxStartMessage
-func PrintSandboxMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
-	PrintSandboxStartMessage(flyteConsolePort, kubeconfigLocation, dryRun)
 }
 
 // PrintSandboxStartMessage will print sandbox start success message

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -72,8 +72,14 @@ func SetupFlyteDir() error {
 	return nil
 }
 
-// PrintDemoMessage will print sandbox success message
+// PrintDemoMessage will print demo start success message
+// Deprecated: use PrintDemoStartMessage
 func PrintDemoMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
+	PrintDemoStartMessage(flyteConsolePort, kubeconfigLocation, dryRun)
+}
+
+// PrintDemoStartMessage will print demo start success message
+func PrintDemoStartMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
 	kubeconfig := strings.Join([]string{
 		"$KUBECONFIG",
 		kubeconfigLocation,
@@ -84,10 +90,9 @@ func PrintDemoMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bo
 		successMsg = fmt.Sprintf("%v http://localhost:%v/console", ProgressSuccessMessagePending, flyteConsolePort)
 	} else {
 		successMsg = fmt.Sprintf("%v http://localhost:%v/console", ProgressSuccessMessage, flyteConsolePort)
-
 	}
 	fmt.Printf("%v %v %v %v %v \n", emoji.ManTechnologist, successMsg, emoji.Rocket, emoji.Rocket, emoji.PartyPopper)
-	fmt.Printf("%v Run the following command to export sandbox environment variables for accessing flytectl\n", emoji.Sparkle)
+	fmt.Printf("%v Run the following command to export demo environment variables for accessing flytectl\n", emoji.Sparkle)
 	fmt.Printf("	export FLYTECTL_CONFIG=%v \n", configutil.FlytectlConfig)
 	if dryRun {
 		fmt.Printf("%v Run the following command to export kubeconfig variables for accessing flyte pods locally\n", emoji.Sparkle)
@@ -97,8 +102,14 @@ func PrintDemoMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bo
 	fmt.Printf("%s The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console\n", emoji.OpenFileFolder)
 }
 
-// PrintSandboxMessage will print sandbox success message
+// PrintSandboxMessage will print sandbox start success message
+// Deprecated: use PrintSandboxStartMessage
 func PrintSandboxMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
+	PrintSandboxStartMessage(flyteConsolePort, kubeconfigLocation, dryRun)
+}
+
+// PrintSandboxStartMessage will print sandbox start success message
+func PrintSandboxStartMessage(flyteConsolePort int, kubeconfigLocation string, dryRun bool) {
 	kubeconfig := strings.Join([]string{
 		"$KUBECONFIG",
 		kubeconfigLocation,
@@ -109,7 +120,6 @@ func PrintSandboxMessage(flyteConsolePort int, kubeconfigLocation string, dryRun
 		successMsg = fmt.Sprintf("%v http://localhost:%v/console", ProgressSuccessMessagePending, flyteConsolePort)
 	} else {
 		successMsg = fmt.Sprintf("%v http://localhost:%v/console", ProgressSuccessMessage, flyteConsolePort)
-
 	}
 	fmt.Printf("%v %v %v %v %v \n", emoji.ManTechnologist, successMsg, emoji.Rocket, emoji.Rocket, emoji.PartyPopper)
 	fmt.Printf("%v Run the following command to export sandbox environment variables for accessing flytectl\n", emoji.Sparkle)
@@ -118,6 +128,12 @@ func PrintSandboxMessage(flyteConsolePort int, kubeconfigLocation string, dryRun
 		fmt.Printf("%v Run the following command to export kubeconfig variables for accessing flyte pods locally\n", emoji.Sparkle)
 		fmt.Printf("	export KUBECONFIG=%v \n", kubeconfig)
 	}
+}
+
+// PrintSandboxTeardownMessage will print sandbox teardown success message
+func PrintSandboxTeardownMessage(flyteConsolePort int, kubeconfigLocation string) {
+	fmt.Printf("%v Run the following command to unset sandbox environment variables for accessing flytectl\n", emoji.Sparkle)
+	fmt.Printf("	unset FLYTECTL_CONFIG \n")
 }
 
 // SendRequest will create request and return the response

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -29,7 +29,7 @@ func TestSetupFlyteDir(t *testing.T) {
 
 func TestPrintSandboxMessage(t *testing.T) {
 	t.Run("Print Sandbox Message", func(t *testing.T) {
-		PrintSandboxMessage(SandBoxConsolePort, docker.SandboxKubeconfig, false)
+		PrintSandboxStartMessage(SandBoxConsolePort, docker.SandboxKubeconfig, false)
 	})
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -27,9 +27,15 @@ func TestSetupFlyteDir(t *testing.T) {
 	assert.Nil(t, SetupFlyteDir())
 }
 
-func TestPrintSandboxMessage(t *testing.T) {
+func TestPrintSandboxStartMessage(t *testing.T) {
 	t.Run("Print Sandbox Message", func(t *testing.T) {
 		PrintSandboxStartMessage(SandBoxConsolePort, docker.SandboxKubeconfig, false)
+	})
+}
+
+func TestPrintSandboxTeardownMessage(t *testing.T) {
+	t.Run("Print Sandbox Message", func(t *testing.T) {
+		PrintSandboxTeardownMessage(SandBoxConsolePort, docker.SandboxKubeconfig)
 	})
 }
 


### PR DESCRIPTION
# TL;DR

Print instruction after execution sandbox/demo teardown command.

This PR also includes a doc build fix similarly as https://github.com/flyteorg/flytekit/pull/1619.

## Type
- [x] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
As described in https://github.com/flyteorg/flyte/issues/3689, it is helpful to guide users cleaning up.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/3689

## Follow-up issue
_NA_
