### PR TITLE
When preleases are allowed for demo sandbox, simply choose the latest release

### DIFF
--- a/pkg/github/githubutil.go
+++ b/pkg/github/githubutil.go
@@ -123,10 +123,11 @@ func GetSandboxImageSha(tag string, pre bool, g GHRepoService) (string, string, 
 			return "", release.GetTagName(), err
 		}
 		for _, v := range releases {
-			if *v.Prerelease && pre {
+			// When pre-releases are allowed, simply choose the latest release
+			if pre {
 				release = v
 				break
-			} else if !*v.Prerelease && !pre {
+			} else if !*v.Prerelease {
 				release = v
 				break
 			}


### PR DESCRIPTION
# TL;DR
When running `flytectl demo start --pre`, the correct behavior should be to choose the latest version, regardless of whether it corresponds to a pre-release.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
