### PR TITLE
#3458 Include default MinIO credentials

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -93,7 +93,7 @@ func PrintDemoStartMessage(flyteConsolePort int, kubeconfigLocation string, dryR
 		fmt.Printf("	export KUBECONFIG=%v \n", kubeconfig)
 	}
 	fmt.Printf("%s Flyte sandbox ships with a Docker registry. Tag and push custom workflow images to localhost:30000\n", emoji.Whale)
-	fmt.Printf("%s The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console\n", emoji.OpenFileFolder)
+	fmt.Printf("%s The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console, default credentials - username: minio, password: miniostorage\n", emoji.OpenFileFolder)
 }
 
 // PrintSandboxStartMessage will print sandbox start success message


### PR DESCRIPTION
#3458 Include default MinIO credentials in sandbox console readout

# TL;DR
Include default MinIO credentials in sandbox console readout

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
When following the [steps](https://docs.flyte.org/en/latest/deployment/deployment/sandbox.html#start-the-sandbox) to setup Flyte on a demo sandbox, the console reports that 📂 The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console. However, in order to view the obect store, you need to use the default credentials for MinIO, which are:

username: minio
password: miniostorage

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3458

