### PR TITLE
Fix the error message for the update cmd

### DIFF
--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -4,7 +4,7 @@ var (
 	ErrInvalidStateUpdate = "invalid state passed. Specify either activate or archive\n"
 
 	ErrProjectNotPassed     = "project id wasn't passed\n" // #nosec
-	ErrProjectNameNotPassed = "project name is a required flag"
+	ErrProjectNameNotPassed = "project name is a required flag\n"
 	ErrFailedProjectUpdate  = "Project %v failed to update due to %v\n"
 
 	ErrLPNotPassed        = "launch plan name wasn't passed\n"

--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -5,7 +5,7 @@ var (
 
 	ErrProjectNotPassed     = "project id wasn't passed\n" // #nosec
 	ErrProjectIDBothPassed  = "both project and id are passed\n"
-	ErrProjectNameNotPassed = "project name is a required flag\n"
+	ErrProjectNameNotPassed = "project name is a required flag"
 	ErrFailedProjectUpdate  = "Project %v failed to update due to %v\n"
 
 	ErrLPNotPassed        = "launch plan name wasn't passed\n"

--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -4,6 +4,7 @@ var (
 	ErrInvalidStateUpdate = "invalid state passed. Specify either activate or archive\n"
 
 	ErrProjectNotPassed     = "project id wasn't passed\n" // #nosec
+	ErrProjectIdBothPassed  = "both project and id are passed\n"
 	ErrProjectNameNotPassed = "project name is a required flag\n"
 	ErrFailedProjectUpdate  = "Project %v failed to update due to %v\n"
 

--- a/clierrors/errors.go
+++ b/clierrors/errors.go
@@ -4,7 +4,7 @@ var (
 	ErrInvalidStateUpdate = "invalid state passed. Specify either activate or archive\n"
 
 	ErrProjectNotPassed     = "project id wasn't passed\n" // #nosec
-	ErrProjectIdBothPassed  = "both project and id are passed\n"
+	ErrProjectIDBothPassed  = "both project and id are passed\n"
 	ErrProjectNameNotPassed = "project name is a required flag\n"
 	ErrFailedProjectUpdate  = "Project %v failed to update due to %v\n"
 

--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -78,7 +78,7 @@ func (c *ConfigProject) GetProjectSpec() (*admin.Project, error) {
 
 	// Get projectId from file, if not provided, fall back to project
 	if len(projectSpec.Id) == 0 {
-		projectSpec.Id = config.GetConfig().Project
+		projectSpec.Id = id
 	}
 	return &projectSpec, nil
 }

--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -74,12 +74,12 @@ func (c *ConfigProject) GetProjectSpec(cf *config.Config) (*admin.Project, error
 
 	project := cf.Project
 	if len(projectSpec.Id) == 0 && len(project) == 0 {
-		err := fmt.Errorf(clierrors.ErrProjectNameNotPassed)
+		err := fmt.Errorf(clierrors.ErrProjectNotPassed)
 		return nil, err
 	}
 
 	if len(projectSpec.Id) > 0 && len(project) > 0 {
-		err := fmt.Errorf(clierrors.ErrProjectIdBothPassed)
+		err := fmt.Errorf(clierrors.ErrProjectIDBothPassed)
 		return nil, err
 	}
 

--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -48,7 +48,7 @@ var DefaultProjectConfig = &ConfigProject{
 // GetProjectSpec return project spec from a file/flags
 func (c *ConfigProject) GetProjectSpec() (*admin.Project, error) {
 	projectSpec := admin.Project{}
-	id := config.GetConfig().Project
+
 	if len(c.File) > 0 {
 		yamlFile, err := ioutil.ReadFile(c.File)
 		if err != nil {
@@ -71,6 +71,8 @@ func (c *ConfigProject) GetProjectSpec() (*admin.Project, error) {
 		}
 		projectSpec.State = projectState
 	}
+
+	id := config.GetConfig().Project
 	if len(projectSpec.Id) == 0 && len(id) == 0 {
 		err := fmt.Errorf(clierrors.ErrProjectNameNotPassed)
 		return nil, err

--- a/cmd/config/subcommand/project/project_config.go
+++ b/cmd/config/subcommand/project/project_config.go
@@ -46,7 +46,7 @@ var DefaultProjectConfig = &ConfigProject{
 }
 
 // GetProjectSpec return project spec from a file/flags
-func (c *ConfigProject) GetProjectSpec() (*admin.Project, error) {
+func (c *ConfigProject) GetProjectSpec(cf *config.Config) (*admin.Project, error) {
 	projectSpec := admin.Project{}
 
 	if len(c.File) > 0 {
@@ -72,15 +72,20 @@ func (c *ConfigProject) GetProjectSpec() (*admin.Project, error) {
 		projectSpec.State = projectState
 	}
 
-	id := config.GetConfig().Project
-	if len(projectSpec.Id) == 0 && len(id) == 0 {
+	project := cf.Project
+	if len(projectSpec.Id) == 0 && len(project) == 0 {
 		err := fmt.Errorf(clierrors.ErrProjectNameNotPassed)
+		return nil, err
+	}
+
+	if len(projectSpec.Id) > 0 && len(project) > 0 {
+		err := fmt.Errorf(clierrors.ErrProjectIdBothPassed)
 		return nil, err
 	}
 
 	// Get projectId from file, if not provided, fall back to project
 	if len(projectSpec.Id) == 0 {
-		projectSpec.Id = id
+		projectSpec.Id = project
 	}
 	return &projectSpec, nil
 }

--- a/cmd/config/subcommand/project/project_config_test.go
+++ b/cmd/config/subcommand/project/project_config_test.go
@@ -13,17 +13,19 @@ import (
 func TestGetProjectSpec(t *testing.T) {
 	t.Run("Successful get project spec", func(t *testing.T) {
 		c := &ConfigProject{
+			ID:   "flytesnacks",
 			Name: "flytesnacks",
 		}
-		response, err := c.GetProjectSpec("flytesnacks")
+		response, err := c.GetProjectSpec()
 		assert.Nil(t, err)
 		assert.NotNil(t, response)
 	})
 	t.Run("Successful get request spec from file", func(t *testing.T) {
 		c := &ConfigProject{
+			ID:   "flytesnacks",
 			File: "testdata/project.yaml",
 		}
-		response, err := c.GetProjectSpec("flytesnacks")
+		response, err := c.GetProjectSpec()
 		assert.Nil(t, err)
 		assert.Equal(t, "flytesnacks", response.Name)
 		assert.Equal(t, "flytesnacks test", response.Description)

--- a/cmd/config/subcommand/project/project_config_test.go
+++ b/cmd/config/subcommand/project/project_config_test.go
@@ -5,27 +5,39 @@ import (
 	"testing"
 
 	"github.com/flyteorg/flytectl/clierrors"
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetProjectSpec(t *testing.T) {
+	cf := &config.Config{
+		Project: "flytesnacks1",
+	}
 	t.Run("Successful get project spec", func(t *testing.T) {
+		c := &ConfigProject{
+			Name: "flytesnacks",
+		}
+		response, err := c.GetProjectSpec(cf)
+		assert.Nil(t, err)
+		assert.Equal(t, "flytesnacks1", response.Id)
+	})
+
+	t.Run("Error if project and ID both exist", func(t *testing.T) {
 		c := &ConfigProject{
 			ID:   "flytesnacks",
 			Name: "flytesnacks",
 		}
-		response, err := c.GetProjectSpec()
-		assert.Nil(t, err)
-		assert.NotNil(t, response)
+		_, err := c.GetProjectSpec(cf)
+		assert.NotNil(t, err)
 	})
+
 	t.Run("Successful get request spec from file", func(t *testing.T) {
 		c := &ConfigProject{
-			ID:   "flytesnacks",
 			File: "testdata/project.yaml",
 		}
-		response, err := c.GetProjectSpec()
+		response, err := c.GetProjectSpec(&config.Config{})
 		assert.Nil(t, err)
 		assert.Equal(t, "flytesnacks", response.Name)
 		assert.Equal(t, "flytesnacks test", response.Description)

--- a/cmd/create/project.go
+++ b/cmd/create/project.go
@@ -45,7 +45,7 @@ Create a project by definition file.
 )
 
 func createProjectsCommand(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(project.DefaultProjectConfig.ID)
+	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec()
 	if err != nil {
 		return err
 	}

--- a/cmd/create/project.go
+++ b/cmd/create/project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flytectl/clierrors"
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 
@@ -45,7 +46,7 @@ Create a project by definition file.
 )
 
 func createProjectsCommand(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec()
+	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(config.GetConfig())
 	if err != nil {
 		return err
 	}

--- a/cmd/create/project_test.go
+++ b/cmd/create/project_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/flyteorg/flytectl/clierrors"
 
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
@@ -36,6 +37,7 @@ func createProjectSetup() {
 	project.DefaultProjectConfig.Name = ""
 	project.DefaultProjectConfig.Labels = map[string]string{}
 	project.DefaultProjectConfig.Description = ""
+	config.GetConfig().Project = ""
 }
 func TestCreateProjectFunc(t *testing.T) {
 	s := setup()

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flytectl/clierrors"
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -82,7 +83,7 @@ Usage
 )
 
 func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec()
+	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(config.GetConfig())
 	if err != nil {
 		return err
 	}

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/flyteorg/flytectl/cmd/config"
-
 	"github.com/flyteorg/flytectl/clierrors"
+	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -85,12 +84,17 @@ Usage
 
 func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
 	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(config.GetConfig().Project)
+
 	if err != nil {
 		return err
 	}
 
-	if projectSpec.Name == "" {
-		return fmt.Errorf(clierrors.ErrProjectNameNotPassed)
+	if project.DefaultProjectConfig.ID != "" {
+		return fmt.Errorf("Project `id` can't be updated. Hint: did you mean `-p` instead of `--id` to specify the project?")
+	}
+
+	if projectSpec.Id == "" {
+		return fmt.Errorf(clierrors.ErrProjectNotPassed)
 	}
 
 	if project.DefaultProjectConfig.DryRun {

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -83,13 +83,8 @@ Usage
 
 func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
 	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec()
-
 	if err != nil {
 		return err
-	}
-
-	if project.DefaultProjectConfig.ID != "" {
-		return fmt.Errorf("Project `id` can't be updated. Hint: did you mean `-p` instead of `--id` to specify the project?")
 	}
 
 	if projectSpec.Id == "" {

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/flyteorg/flytectl/clierrors"
-	"github.com/flyteorg/flytectl/cmd/config"
 	"github.com/flyteorg/flytectl/cmd/config/subcommand/project"
 	cmdCore "github.com/flyteorg/flytectl/cmd/core"
 	"github.com/flyteorg/flytestdlib/logger"
@@ -83,7 +82,7 @@ Usage
 )
 
 func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.CommandContext) error {
-	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec(config.GetConfig().Project)
+	projectSpec, err := project.DefaultProjectConfig.GetProjectSpec()
 
 	if err != nil {
 		return err

--- a/cmd/update/project.go
+++ b/cmd/update/project.go
@@ -54,7 +54,7 @@ Update projects.(project/projects can be used interchangeably in these commands)
 Update a project by definition file. Note: The name shouldn't contain any whitespace characters.
 ::
 
- flytectl update project --file project.yaml 
+ flytectl update project --file project.yaml
 
 .. code-block:: yaml
 
@@ -88,8 +88,9 @@ func updateProjectsFunc(ctx context.Context, args []string, cmdCtx cmdCore.Comma
 	if err != nil {
 		return err
 	}
-	if projectSpec.Id == "" {
-		return fmt.Errorf(clierrors.ErrProjectNotPassed)
+
+	if projectSpec.Name == "" {
+		return fmt.Errorf(clierrors.ErrProjectNameNotPassed)
 	}
 
 	if project.DefaultProjectConfig.DryRun {


### PR DESCRIPTION
Fix Flyte's #3806 [Housekeeping] Inconsistent treatment of project id param in flytectl


# TL;DR
As project name is required rather than project id, check name instead.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/3806)

### Updated behavior
```
❯ ./bin/flytectl update project -p flytesnack --id flytesnack3
Error: both project and id are passed
❯ ./bin/flytectl update project -p flytesnacks --name flytesnack3
Project flytesnacks updated
❯ ./bin/flytectl update project --id flytesnacks --name flytesnack3
Project flytesnacks updated```