### PR TITLE
Fix functional tests by pinning golang version to 1.19.10

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -152,6 +152,10 @@ jobs:
     name: Goreleaser
     needs: [ bump_version ] # Only to ensure it can successfully build
     uses: flyteorg/flytetools/.github/workflows/goreleaser.yml@master
+    with:
+      # https://github.com/docker/cli/issues/4437 describes an issue that affects the latest
+      # version of go 1.19 and 1.20, so pinning to latest known good version for now.
+      go-version: "1.19.10"
     secrets:
       FLYTE_BOT_PAT: ${{ secrets.FLYTE_BOT_PAT }}
 


### PR DESCRIPTION
# TL;DR
Latest releases of go broke some of the docker cli commands, which ended up breaking functional tests

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
https://github.com/docker/cli/issues/4437 has more details, but basically the latest version of the docker-cli doesn't work with go versions 1.19.11 and 1.20.5. This PR forces the version of the docker client installed in the sandbox image to 1.19.10.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
