### PR TITLE
fix(flytectl): Update FetchWorkflowLatestVersion to fetch the latest version of a workflow

### DIFF
--- a/pkg/ext/workflow_fetcher.go
+++ b/pkg/ext/workflow_fetcher.go
@@ -49,7 +49,7 @@ func (a *AdminFetcherExtClient) FetchWorkflowLatestVersion(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	return a.FetchWorkflowVersion(ctx, name, wVersions[0].Id.Version, project, domain)
+	return a.FetchWorkflowVersion(ctx, name, wVersions[len(wVersions)-1].Id.Version, project, domain)
 }
 
 // FetchWorkflowVersion fetches particular version of workflow


### PR DESCRIPTION
# TL;DR

Fix the `FetchWorkflowLatestVersion` function in flytectl to return the latest workflow version.


## Type

 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

The `FetchWorkflowLatestVersion` function in `workflow_fetcher.go` has been updated to retrieve the latest workflow version by using the last element in the `wVersions` slice. This change ensures that the most recent version is fetched when calling this function.

## Tracking Issue

fixes [3972](https://github.com/flyteorg/flyte/issues/3972)

