### PR TITLE
Fix case for No string to no in command utils

### DIFF
--- a/pkg/commandutils/command_utils.go
+++ b/pkg/commandutils/command_utils.go
@@ -14,7 +14,7 @@ func AskForConfirmation(s string, reader io.Reader) bool {
 		response := strings.ToLower(strings.TrimSpace(r.Text()))
 		if response == "y" || response == "yes" {
 			return true
-		} else if response == "n" || response == "No" {
+		} else if response == "n" || response == "no" {
 			return false
 		}
 	}


### PR DESCRIPTION
# TL;DR
As title.

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
The "No" string should be lowercase.