### PR TITLE
Add necessary header and update response status check for uploaded artifacts to Azure blob storage

### DIFF
--- a/cmd/register/register_util.go
+++ b/cmd/register/register_util.go
@@ -808,6 +808,7 @@ func DirectUpload(url string, contentMD5 []byte, size int64, data io.Reader) err
 	req.ContentLength = size
 	req.Header.Set("Content-Length", strconv.FormatInt(size, 10))
 	req.Header.Set("Content-MD5", base64.StdEncoding.EncodeToString(contentMD5))
+	req.Header.Set("x-ms-blob-type", "BlockBlob")
 
 	client := &http.Client{}
 	res, err := client.Do(req)
@@ -815,7 +816,7 @@ func DirectUpload(url string, contentMD5 []byte, size int64, data io.Reader) err
 		return err
 	}
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		raw, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return fmt.Errorf("received response code [%v]. Failed to read response body. Error: %w", res.StatusCode, err)


### PR DESCRIPTION
# TL;DR
While registering files that is created for fast registration to Azure blob storage, operation fails due to a missing required header. This change adds the missing header and also adds the accepted http response 201(CREATED) which is the default response for successful upload operations. 


## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
During upload operation the following error message is thrown.
```
Error: failed to upload source code from [/tmp/flyte/pb_output/fast1ac88c953907bcb2a3ca7a6377277465.tar.gz]. Error: failed uploading to [<blob-location>]. bad status: 400 An HTTP header that's mandatory for this request is not specified.: <?xml version="1.0" encoding="utf-8"?>
<Error><Code>MissingRequiredHeader</Code><Message>An HTTP header that&apos;s mandatory for this request is not specified.
RequestId:d7bbcada-101e-0025-4281-ecea10000000
Time:2023-09-21T11:46:16.3019574Z</Message><HeaderName>x-ms-blob-type</HeaderName></Error>
{"json":{},"level":"error","msg":"failed to upload source code from [/tmp/flyte/pb_output/fast1ac88c953907bcb2a3ca7a6377277465.tar.gz]. Error: failed uploading to [<blob-location>]. bad status: 400 An HTTP header that's mandatory for this request is not specified.: \u003c?xml version=\"1.0\" encoding=\"utf-8\"?\u003e\n\u003cError\u003e\u003cCode\u003eMissingRequiredHeader\u003c/Code\u003e\u003cMessage\u003eAn HTTP header that\u0026apos;s mandatory for this request is not specified.\nRequestId:d7bbcada-101e-0025-4281-ecea10000000\nTime:2023-09-21T11:46:16.3019574Z\u003c/Message\u003e\u003cHeaderName\u003ex-ms-blob-type\u003c/HeaderName\u003e\u003c/Error\u003e","ts":"2023-09-21T11:46:16Z"}
```
In the error message it explains the issue which is a missing header. Added the header to the request and updated response check to accept 201 as a successful http response type. 

## Tracking Issue
_NA_

## Follow-up issue
_NA_
