### PR TITLE
Hide global flags when printing help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,29 @@ func newRootCmd() *cobra.Command {
 
 	config.GetConfig()
 
+	// hide global flags
+	rootCmd.SetUsageTemplate(`Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`)
+
 	return rootCmd
 }
 


### PR DESCRIPTION
# TL;DR
Hide global flags when printing help in order to keep useful info in the screen.

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Override the usage template of cobra with deleting `Global Flags` section.
Now `flytectl <command> --help` will only show the flags for this particular command.
All flags can still be shown when execute `flytectl --help` in `Flags` section.

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/3352](https://github.com/flyteorg/flyte/issues/3352)

## Follow-up issue
_NA_
