### PR TITLE
[FlyteCTL Feature] Add `--force` flag to `flytectl config init`

### DIFF
--- a/cmd/config/subcommand/config/config_flags.go
+++ b/cmd/config/subcommand/config/config_flags.go
@@ -53,5 +53,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.StringVar(&DefaultConfig.Console, fmt.Sprintf("%v%v", prefix, "console"), DefaultConfig.Console, "Endpoint of console,  if different than flyte admin")
 	cmdFlags.StringVar(&DefaultConfig.Host, fmt.Sprintf("%v%v", prefix, "host"), DefaultConfig.Host, "Endpoint of flyte admin")
 	cmdFlags.BoolVar(&DefaultConfig.Insecure, fmt.Sprintf("%v%v", prefix, "insecure"), DefaultConfig.Insecure, "Enable insecure mode")
+	cmdFlags.BoolVar(&DefaultConfig.Force, fmt.Sprintf("%v%v", prefix, "force"), DefaultConfig.Force, "Force to overwrite the default config file without confirmation")
 	return cmdFlags
 }

--- a/cmd/config/subcommand/config/config_flags_test.go
+++ b/cmd/config/subcommand/config/config_flags_test.go
@@ -141,4 +141,18 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_force", func(t *testing.T) {
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("force", testValue)
+			if vBool, err := cmdFlags.GetBool("force"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.Force)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/cmd/config/subcommand/config/init_flags.go
+++ b/cmd/config/subcommand/config/init_flags.go
@@ -4,6 +4,7 @@ package config
 var (
 	DefaultConfig = &Config{
 		Insecure: false,
+		Force:    false,
 	}
 )
 
@@ -12,4 +13,5 @@ type Config struct {
 	Console  string `json:"console" pflag:",Endpoint of console, if different than flyte admin"`
 	Host     string `json:"host" pflag:",Endpoint of flyte admin"`
 	Insecure bool   `json:"insecure" pflag:",Enable insecure mode"`
+	Force    bool   `json:"force" pflag:",Force to overwrite the default config file without confirmation"`
 }

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -70,6 +70,8 @@ func CreateConfigCommand() *cobra.Command {
 			Long:  initCmdLong, PFlagProvider: initConfig.DefaultConfig},
 	}
 
+	configCmd.Flags().BoolVar(&initConfig.DefaultConfig.Force, "force", false, "Force to overwrite the default config file without confirmation")
+
 	cmdcore.AddCommands(configCmd, getResourcesFuncs)
 	return configCmd
 }
@@ -109,7 +111,7 @@ func initFlytectlConfig(reader io.Reader) error {
 	if _, err := os.Stat(configutil.ConfigFile); os.IsNotExist(err) {
 		_err = configutil.SetupConfig(configutil.ConfigFile, templateStr, templateValues)
 	} else {
-		if cmdUtil.AskForConfirmation(fmt.Sprintf("This action will overwrite an existing config file at [%s]. Do you want to continue?", configutil.ConfigFile), reader) {
+		if initConfig.DefaultConfig.Force || cmdUtil.AskForConfirmation(fmt.Sprintf("This action will overwrite an existing config file at [%s]. Do you want to continue?", configutil.ConfigFile), reader) {
 			if err := os.Remove(configutil.ConfigFile); err != nil {
 				return err
 			}

--- a/cmd/configuration/configuration_test.go
+++ b/cmd/configuration/configuration_test.go
@@ -41,12 +41,12 @@ func TestCreateInitCommand(t *testing.T) {
 	assert.Equal(t, initCmdShort, cmdNouns[2].Short)
 	assert.Equal(t, "validate", cmdNouns[3].Use)
 	assert.Equal(t, "Validates the loaded config.", cmdNouns[3].Short)
-
 }
 
 func TestSetupConfigFunc(t *testing.T) {
 	var yes = strings.NewReader("Yes")
 	var no = strings.NewReader("No")
+	var empty = strings.NewReader("")
 	mockOutStream := new(io.Writer)
 	ctx := context.Background()
 	_ = os.Remove(configutil.FlytectlConfig)
@@ -59,8 +59,13 @@ func TestSetupConfigFunc(t *testing.T) {
 	initConfig.DefaultConfig.Host = ""
 	assert.Nil(t, err)
 
+	initConfig.DefaultConfig.Force = false
 	assert.Nil(t, initFlytectlConfig(yes))
 	assert.Nil(t, initFlytectlConfig(no))
+
+	initConfig.DefaultConfig.Force = true
+	assert.Nil(t, initFlytectlConfig(empty))
+
 	initConfig.DefaultConfig.Host = "flyte.org"
 	assert.Nil(t, initFlytectlConfig(no))
 	initConfig.DefaultConfig.Host = "localhost:30081"
@@ -85,4 +90,12 @@ func TestValidateEndpointName(t *testing.T) {
 	assert.Equal(t, true, validateEndpointName("112.11.1.1:8080"))
 	assert.Equal(t, false, validateEndpointName("112.11.1.1:8080/console"))
 	assert.Equal(t, false, validateEndpointName("flyte"))
+}
+
+func TestForceFlagInCreateConfigCommand(t *testing.T) {
+	cmd := CreateConfigCommand()
+	assert.False(t, initConfig.DefaultConfig.Force)
+	err := cmd.Flags().Parse([]string{"--force"})
+	assert.Nil(t, err)
+	assert.True(t, initConfig.DefaultConfig.Force)
 }


### PR DESCRIPTION
# TL;DR
Now we can use `flytectl config init --force` without enter "y".

## Type
- [ ] Bug Fix
- [x] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue 

## Complete description
Before this PR, we need to enter "y" after using `flytectl config init`.
![image](https://github.com/flyteorg/flytectl/assets/76461262/a88198f3-3cc6-491a-bf0f-8ed1c54c9bec)

Now, we can use run flytectl `config init --force` to force an update to the default config file.
![image](https://github.com/flyteorg/flytectl/assets/76461262/306f4131-e598-4d23-99d5-c97c78a87f1e)


## Tracking Issue
https://github.com/flyteorg/flyte/issues/3469

