### PR TITLE
Misc cleanups to aesthetics

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build Flytectl binary
         run: make compile
       - name: Create a sandbox cluster
-        run: bin/flytectl sandbox start
+        run: bin/flytectl demo start
       - name: Setup flytectl config
         run: bin/flytectl config init
       - name: Register cookbook

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -63,6 +63,7 @@ jobs:
     name: Test Getting started
     runs-on: ubuntu-latest
     steps:
+      - uses: insightsengineering/disk-space-reclaimer@v1
       - name: Checkout
         uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,7 +79,13 @@ jobs:
       - name: Build Flytectl binary
         run: make compile
       - name: Create a sandbox cluster
-        run: bin/flytectl demo start
+        run: |
+          bin/flytectl demo start
+          # Sleep is necessary here since `flyte-proxy` might not be ready
+          # to serve requests when the above command exits successfully.
+          # Fixed in: https://github.com/flyteorg/flyte/pull/4348
+          # TODO (jeev): Remove this when ^ is released.
+          sleep 5
       - name: Setup flytectl config
         run: bin/flytectl config init
       - name: Register cookbook

--- a/cmd/configuration/configuration.go
+++ b/cmd/configuration/configuration.go
@@ -87,7 +87,7 @@ func initFlytectlConfig(reader io.Reader) error {
 	}
 
 	templateValues := configutil.ConfigTemplateSpec{
-		Host:     "dns:///localhost:30081",
+		Host:     "dns:///localhost:30080",
 		Insecure: true,
 	}
 	templateStr := configutil.GetTemplate()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/flyteorg/flytectl
 go 1.19
 
 require (
+	github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/awalterschulze/gographviz v2.0.3+incompatible
 	github.com/disiqueira/gotree v1.0.0
@@ -22,6 +23,7 @@ require (
 	github.com/kataras/tablewriter v0.0.0-20180708051242-e063d29b7c23
 	github.com/landoop/tableprinter v0.0.0-20180806200924-8bd8c2576d27
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635
 	github.com/mouuff/go-rocket-update v1.5.1
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4
@@ -54,6 +56,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v0.23.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v0.9.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.4.0 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.27 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.18 // indirect
@@ -113,7 +116,6 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
-	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	k8s.io/api v0.24.1
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1
+	k8s.io/kubernetes v1.13.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5 h1:VYqcjykqpcq262cDxBAkAelSdg6HETkxgwzQRTS40Aw=
+github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5/go.mod h1:E7x8aDc3AQzDKjEoIZCt+XYheHk2OkP+p2UgeNjecH8=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
@@ -282,6 +284,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKY
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/go.sum
+++ b/go.sum
@@ -1429,6 +1429,7 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42/go.mod h1:Z/45zLw8lUo4wdiUkI+v/ImEGAvu3WatcZl3lPMR4Rk=
 k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5FJ2kxm1WrQFanWchyKuqGg=
 k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
+k8s.io/kubernetes v1.13.0 h1:qTfB+u5M92k2fCCCVP2iuhgwwSOv1EkAkvQY1tQODD8=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20210802155522-efc7438f0176/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/pkg/k8s/mocks/context_ops.go
+++ b/pkg/k8s/mocks/context_ops.go
@@ -53,8 +53,8 @@ func (_m ContextOps_CopyContext) Return(_a0 error) *ContextOps_CopyContext {
 	return &ContextOps_CopyContext{Call: _m.Call.Return(_a0)}
 }
 
-func (_m *ContextOps) OnCopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName string, targetCtxName string) *ContextOps_CopyContext {
-	c_call := _m.On("CopyContext", srcConfigAccess, srcCtxName, targetCtxName)
+func (_m *ContextOps) OnCopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName string, targetCtxName string, targetNamespace string) *ContextOps_CopyContext {
+	c_call := _m.On("CopyContext", srcConfigAccess, srcCtxName, targetCtxName, targetNamespace)
 	return &ContextOps_CopyContext{Call: c_call}
 }
 
@@ -63,13 +63,13 @@ func (_m *ContextOps) OnCopyContextMatch(matchers ...interface{}) *ContextOps_Co
 	return &ContextOps_CopyContext{Call: c_call}
 }
 
-// CopyContext provides a mock function with given fields: srcConfigAccess, srcCtxName, targetCtxName
-func (_m *ContextOps) CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName string, targetCtxName string) error {
-	ret := _m.Called(srcConfigAccess, srcCtxName, targetCtxName)
+// CopyContext provides a mock function with given fields: srcConfigAccess, srcCtxName, targetCtxName, targetNamespace
+func (_m *ContextOps) CopyContext(srcConfigAccess clientcmd.ConfigAccess, srcCtxName string, targetCtxName string, targetNamespace string) error {
+	ret := _m.Called(srcConfigAccess, srcCtxName, targetCtxName, targetNamespace)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(clientcmd.ConfigAccess, string, string) error); ok {
-		r0 = rf(srcConfigAccess, srcCtxName, targetCtxName)
+	if rf, ok := ret.Get(0).(func(clientcmd.ConfigAccess, string, string, string) error); ok {
+		r0 = rf(srcConfigAccess, srcCtxName, targetCtxName, targetNamespace)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/sandbox/start_test.go
+++ b/pkg/sandbox/start_test.go
@@ -317,7 +317,7 @@ func TestStartFunc(t *testing.T) {
 		k8s.ContextMgr = mockK8sContextMgr
 		ghutil.Client = githubMock
 		mockK8sContextMgr.OnCheckConfig().Return(nil)
-		mockK8sContextMgr.OnCopyContextMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		mockK8sContextMgr.OnCopyContextMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		err = StartSandboxCluster(context.Background(), []string{}, config)
 		assert.Nil(t, err)
 	})

--- a/pkg/sandbox/start_test.go
+++ b/pkg/sandbox/start_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -97,6 +98,10 @@ func sandboxSetup() {
 	mockDocker.OnContainerWaitMatch(ctx, mock.Anything, container.WaitConditionNotRunning).Return(bodyStatus, errCh)
 }
 
+func dummyReader() io.ReadCloser {
+	return io.NopCloser(strings.NewReader(""))
+}
+
 func TestStartFunc(t *testing.T) {
 	defaultImagePrefix := "dind"
 	exposedPorts, portBindings, _ := docker.GetSandboxPorts()
@@ -117,7 +122,7 @@ func TestStartFunc(t *testing.T) {
 	t.Run("Successfully run demo cluster", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
@@ -127,7 +132,7 @@ func TestStartFunc(t *testing.T) {
 		}).Return(nil, nil)
 		mockDocker.OnVolumeList(ctx, filters.NewArgs(filters.KeyValuePair{Key: mock.Anything, Value: mock.Anything})).Return(volume.VolumeListOKBody{Volumes: []*types.Volume{}}, nil)
 		mockDocker.OnVolumeCreate(ctx, volume.VolumeCreateBody{Name: mock.Anything}).Return(types.Volume{}, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully exit when demo cluster exist", func(t *testing.T) {
@@ -140,7 +145,7 @@ func TestStartFunc(t *testing.T) {
 				},
 			},
 		}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
@@ -158,14 +163,14 @@ func TestStartFunc(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
 			Follow:     true,
 		}).Return(nil, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully run demo cluster with abs path of source code", func(t *testing.T) {
@@ -174,21 +179,21 @@ func TestStartFunc(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
 			Timestamps: true,
 			Follow:     true,
 		}).Return(nil, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.Nil(t, err)
 	})
 	t.Run("Successfully run demo cluster with specific version", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
 			ShowStdout: true,
@@ -202,7 +207,7 @@ func TestStartFunc(t *testing.T) {
 		}, nil, nil)
 
 		githubMock.OnGetCommitSHA1Match(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("dummySha", nil, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.Nil(t, err)
 	})
 	t.Run("Failed run demo cluster with wrong version", func(t *testing.T) {
@@ -210,14 +215,14 @@ func TestStartFunc(t *testing.T) {
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
 		sandboxCmdConfig.DefaultConfig.Image = ""
 		githubMock.OnGetReleaseByTagMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("non-existent-tag"))
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "non-existent-tag", err.Error())
 	})
 	t.Run("Error in pulling image", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, fmt.Errorf("failed to pull"))
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), fmt.Errorf("failed to pull"))
 		sandboxCmdConfig.DefaultConfig.Image = ""
 		tag := "v0.15.0"
 		githubMock.OnGetReleaseByTagMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&github.RepositoryRelease{
@@ -225,7 +230,7 @@ func TestStartFunc(t *testing.T) {
 		}, nil, nil)
 
 		githubMock.OnGetCommitSHA1Match(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("dummySha", nil, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to pull", err.Error())
 	})
@@ -239,7 +244,7 @@ func TestStartFunc(t *testing.T) {
 				},
 			},
 		}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerRemove(ctx, mock.Anything, types.ContainerRemoveOptions{Force: true}).Return(fmt.Errorf("failed to remove container"))
 		_, err := startSandbox(ctx, mockDocker, githubMock, strings.NewReader("y"), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
@@ -248,16 +253,16 @@ func TestStartFunc(t *testing.T) {
 	t.Run("Error in start container", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(fmt.Errorf("failed to run container"))
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to run container", err.Error())
 	})
 	t.Run("Error in reading logs", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
@@ -265,14 +270,14 @@ func TestStartFunc(t *testing.T) {
 			Timestamps: true,
 			Follow:     true,
 		}).Return(nil, fmt.Errorf("failed to get container logs"))
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), sandboxCmdConfig.DefaultConfig, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to get container logs", err.Error())
 	})
 	t.Run("Error in list container", func(t *testing.T) {
 		sandboxSetup()
 		mockDocker.OnContainerListMatch(mock.Anything, mock.Anything).Return([]types.Container{}, fmt.Errorf("failed to list containers"))
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,
@@ -280,7 +285,7 @@ func TestStartFunc(t *testing.T) {
 			Timestamps: true,
 			Follow:     true,
 		}).Return(nil, nil)
-		_, err := startSandbox(ctx, mockDocker, githubMock, os.Stdin, config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
+		_, err := startSandbox(ctx, mockDocker, githubMock, dummyReader(), config, sandboxImageName, defaultImagePrefix, exposedPorts, portBindings, util.SandBoxConsolePort)
 		assert.NotNil(t, err)
 		assert.Equal(t, "failed to list containers", err.Error())
 	})
@@ -300,7 +305,7 @@ func TestStartFunc(t *testing.T) {
 		}
 		sandboxSetup()
 		mockDocker.OnContainerList(ctx, types.ContainerListOptions{All: true}).Return([]types.Container{}, nil)
-		mockDocker.OnImagePullMatch(mock.Anything, mock.Anything, mock.Anything).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(mock.Anything, mock.Anything, mock.Anything).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		stringReader := strings.NewReader(docker.SuccessMessage)
 		reader := ioutil.NopCloser(stringReader)
@@ -327,7 +332,7 @@ func TestStartFunc(t *testing.T) {
 		sandboxSetup()
 		docker.Client = mockDocker
 		mockDocker.OnContainerListMatch(mock.Anything, mock.Anything).Return([]types.Container{}, fmt.Errorf("failed to list containers"))
-		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(os.Stdin, nil)
+		mockDocker.OnImagePullMatch(ctx, mock.Anything, types.ImagePullOptions{}).Return(dummyReader(), nil)
 		mockDocker.OnContainerStart(ctx, "Hello", types.ContainerStartOptions{}).Return(nil)
 		mockDocker.OnContainerLogsMatch(ctx, mock.Anything, types.ContainerLogsOptions{
 			ShowStderr: true,

--- a/pkg/sandbox/start_test.go
+++ b/pkg/sandbox/start_test.go
@@ -70,8 +70,17 @@ var fakeNode = &corev1.Node{
 
 var fakePod = corev1.Pod{
 	Status: corev1.PodStatus{
-		Phase:      corev1.PodRunning,
-		Conditions: []corev1.PodCondition{},
+		Phase: corev1.PodRunning,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			},
+			{
+				Type:   corev1.ContainersReady,
+				Status: corev1.ConditionTrue,
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
# TL;DR
1. Fixes some aesthetics:
    - Missing emojis
    - Ugly progress bar when pulling image
    - Unnecessary clear screen when printing pod startup progress
2. Sets `flyte` as the namespace for the `flyte-sandbox` context since `default` is empty.
3. Update `flytectl config init` to use endpoint with port `30080` instead of the legacy `30081`
4. Fix `Testing Getting started` GitHub job to use `flytectl demo start` instead of the legacy `flytectl sandbox start`
5. Wait for pod to be in a ready condition instead of simply polling for a `Running` phase.

Pulling image:
```
> go run main.go demo start --dev
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [console] updated. No update handler registered.","ts":"2023-11-01T02:04:31-07:00"}
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [files] updated. No update handler registered.","ts":"2023-11-01T02:04:31-07:00"}
{"json":{"src":"viper.go:400"},"level":"debug","msg":"Config section [admin] updated. Firing updated event.","ts":"2023-11-01T02:04:31-07:00"}
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [storage] updated. No update handler registered.","ts":"2023-11-01T02:04:31-07:00"}
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [root] updated. No update handler registered.","ts":"2023-11-01T02:04:31-07:00"}
🧑‍🏭 Bootstrapping a brand new Flyte cluster... 🔨 🔧
{"json":{"src":"githubutil.go:135"},"level":"info","msg":"starting with release v1.10.0","ts":"2023-11-01T02:04:33-07:00"}
🐋 Going to use Flyte v1.10.0 release with image cr.flyte.org/flyteorg/flyte-sandbox-bundled:sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734
🐋 Pulling image cr.flyte.org/flyteorg/flyte-sandbox-bundled:sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734
sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734: Pulling from flyteorg/flyte-sandbox-bundled
a979e9cd3052: Downloading [======================================>            ]  51.86MB/66.56MB
f6a97a38429d: Download complete
cc8797e90a60: Downloading [================>                                  ]  152.4MB/464.3MB
e49dce66b1ec: Downloading [========>                                          ]  13.51MB/79.36MB
f1233bc3b2e7: Waiting
a68cc7c2ab6d: Waiting
c8c3f1f88dac: Waiting
```

Done:
```
> go run main.go demo start --dev
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [console] updated. No update handler registered.","ts":"2023-11-01T02:16:52-07:00"}
{"json":{"src":"viper.go:398"},"level":"debug","msg":"Config section [files] updated. No update handler registered.","ts":"2023-11-01T02:16:52-07:00"}
{"json":{"src":"viper.go:400"},"level":"debug","msg":"Config section [admin] updated. Firing updated event.","ts":"2023-11-01T02:16:52-07:00"}
🧑‍🏭 Bootstrapping a brand new Flyte cluster... 🔨 🔧
{"json":{"src":"githubutil.go:135"},"level":"info","msg":"starting with release v1.10.0","ts":"2023-11-01T02:16:53-07:00"}
🐋 Going to use Flyte v1.10.0 release with image cr.flyte.org/flyteorg/flyte-sandbox-bundled:sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734
🐋 Pulling image cr.flyte.org/flyteorg/flyte-sandbox-bundled:sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734
sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734: Pulling from flyteorg/flyte-sandbox-bundled
a979e9cd3052: Pull complete
f6a97a38429d: Pull complete
cc8797e90a60: Pull complete
e49dce66b1ec: Pull complete
f1233bc3b2e7: Pull complete
a68cc7c2ab6d: Pull complete
c8c3f1f88dac: Pull complete
Digest: sha256:71665d019657e9f93585ff21743559006909833a4dac2ff1b616491c2599b815
Status: Downloaded newer image for cr.flyte.org/flyteorg/flyte-sandbox-bundled:sha-fa49d3bfcdc081328e2f1514fd513ec46fdbf734
🧑‍🏭 Starting container... 🔨 🔧
⏳ Waiting for cluster to come up... ⏳
🧑‍🏭 Activated context "flyte-sandbox"!
+-----------------------------------------------------+---------------+-----------+
|                       SERVICE                       |    STATUS     | NAMESPACE |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-kubernetes-dashboard-6757db879c-d2bqk | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-proxy-d95874857-jw8rp                 | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-docker-registry-57cb4c44bb-tv9mj      | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-buildkit-7d7d55dbb-gn7ph              | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-postgresql-0                          | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
| flyte-sandbox-minio-645c8ddf7c-dnnpn                | Running       | flyte     |
+-----------------------------------------------------+---------------+-----------+
👨‍💻 Flyte is ready! Flyte UI is available at http://localhost:30080/console 🚀 🚀 🎉
❇️ Run the following command to export demo environment variables for accessing flytectl
	export FLYTECTL_CONFIG=/Users/jeev/.flyte/config-sandbox.yaml
🐋 Flyte sandbox ships with a Docker registry. Tag and push custom workflow images to localhost:30000
📂 The Minio API is hosted on localhost:30002. Use http://localhost:30080/minio/login for Minio console
```

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [x] Smoke tested
- [x] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
