### PR TITLE
add monodocs build to ci in flytectl

### DIFF
--- a/.github/workflows/monodocs_build.yml
+++ b/.github/workflows/monodocs_build.yml
@@ -1,4 +1,4 @@
-name: Docs Build
+name: Monodocs Build
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -13,7 +13,7 @@ on:
       - master
 jobs:
   docs:
-    name: Docs Build
+    name: Monodocs Build
     runs-on: ubuntu-latest
     steps:
       - name: Fetch flytectl code


### PR DESCRIPTION
Fixes https://github.com/flyteorg/flyte/issues/4559

# TL;DR

This PR adds a github action for building `flyteorg/flyte` monodoc so we can catch breaking changes in this upstream repo.

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin
- [x] Housekeeping

## Are all requirements met?

- [x] Code completed

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/4559)
