### PR TITLE
Update typo nodID -> nodeID in execution.go, flytectl_get_execution.rst #none

### DIFF
--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -82,7 +82,7 @@ Task execution view is available in YAML/JSON format too. The following example 
 
 ::
 
- flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodID n0 -o yaml
+ flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodeID n0 -o yaml
 
 Usage
 `

--- a/docs/source/gen/flytectl_get_execution.rst
+++ b/docs/source/gen/flytectl_get_execution.rst
@@ -75,7 +75,7 @@ Task execution view is available in YAML/JSON format too. The following example 
 
 ::
 
- flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodID n0 -o yaml
+ flytectl get execution -p flytesnacks -d development oeh94k9r2r --nodeID n0 -o yaml
 
 Usage
 


### PR DESCRIPTION
# TL;DR
The usage examples for `flytectl get` was broken because `nodeID` was replaced with `nodID` (no `e`). I fixed it.

## Type
- [x] Bug Fix

## Are all requirements met?

It's just a typo fix, all are irrelevant afaik.

- [ ] ~Code completed~
- [ ] ~Smoke tested~
- [ ] ~Unit tests added~
- [ ] ~Code documentation added~
- [ ] ~Any pending items have an associated Issue~

## Complete description
I fixed a typo :)

## Tracking Issue
_NA_

## Follow-up issue
_NA_
