### PR TITLE
add monodocs redirect banner

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,15 +93,24 @@ html_title = "Flyte"
 html_logo = "flyte_circle_gradient_1_4x4.png"
 html_favicon = "flyte_circle_gradient_1_4x4.png"
 
+announcement = """
+📢 This is the old documentation for Flyte.
+Please visit the new documentation <a href="https://docs.flyte.org">here</a>.
+"""
+
 html_theme_options = {
     "light_css_variables": {
         "color-brand-primary": "#4300c9",
         "color-brand-content": "#4300c9",
+        "color-announcement-background": "#FEE7B8",
+        "color-announcement-text": "#535353",
     },
     "dark_css_variables": {
         "color-brand-primary": "#9D68E4",
         "color-brand-content": "#9D68E4",
+        "color-announcement-background": "#493100",
     },
+    "announcement": announcement,
 }
 
 html_context = {


### PR DESCRIPTION
This PR adds a banner at the top of the flytesnacks docs (the flytekit readthedocs project), pointing users to the main flyte docs site, which will contain the monodocs.