### PR TITLE
Adding execution details in the list view

### DIFF
--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -112,8 +112,8 @@ func ExecutionToProtoMessages(l []*admin.Execution) []proto.Message {
 
 // Combines the exeuction along with details
 type executionWithDetails struct {
-	Executions *admin.Execution
-	Details    []*NodeExecutionClosure
+	Execution *admin.Execution
+	Details   []*NodeExecutionClosure
 }
 
 func (e *executionWithDetails) Reset() {
@@ -179,8 +179,8 @@ func getExecutionFunc(ctx context.Context, args []string, cmdCtx cmdCore.Command
 				return err
 			}
 			allExecutionWithDetails = append(allExecutionWithDetails, &executionWithDetails{
-				Executions: exec,
-				Details:    nExecDetailsForView,
+				Execution: exec,
+				Details:   nExecDetailsForView,
 			})
 		}
 		logger.Infof(ctx, "Retrieved %v executions", len(allExecutionWithDetails))


### PR DESCRIPTION

# TL;DR
Add --details support to the list view 


Test o/p with jq to search for inputs

```
 flytectl get executions -p flytesnacks -d development --details |jq '.. | select(.Details? // empty | any(.inputs?.run_date == "2024-02-08T02:42:00Z"))' 
{
  "Execution": {
    "id": {
      "project": "flytesnacks",
      "domain": "development",
      "name": "f7f2026572f57fb57000"
    },
    "spec": {
      "launch_plan": {
        "resource_type": 3,
        "project": "flytesnacks",
        "domain": "development",
        "name": "my_cron_scheduled_lp",
        "version": "v0.3.257"
      },
      "metadata": {
        "mode": 1,
        "principal": "dogfood-flyteadmin",
        "scheduled_at": {
          "seconds": 1707360120
        },
        "system_metadata": {
          "execution_cluster": "oc-staging",
          "namespace": "flytesnacks-development"
        }
      },
      "NotificationOverrides": null,
      "security_context": {
        "run_as": {}
      }
    },
    "closure": {
      "OutputResult": {
        "Outputs": {
          "Data": {
            "Uri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/offloaded_outputs"
          }
        }
      },
      "phase": 4,
      "started_at": {
        "seconds": 1707360120,
        "nanos": 662379590
      },
      "duration": {
        "seconds": 5,
        "nanos": 499620629
      },
      "created_at": {
        "seconds": 1707360120,
        "nanos": 265961016
      },
      "updated_at": {
        "seconds": 1707360126,
        "nanos": 161999629
      },
      "workflow_id": {
        "resource_type": 2,
        "project": "flytesnacks",
        "domain": "development",
        "name": "productionizing.lp_schedules.date_formatter_wf",
        "version": "v0.3.257"
      },
      "state_change_details": {
        "occurred_at": {
          "seconds": 1707360120,
          "nanos": 265961016
        },
        "principal": "dogfood-flyteadmin"
      }
    }
  },
  "Details": [
    {
      "node_exec": {
        "id": {
          "nodeId": "start-node",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f7f2026572f57fb57000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/start-node/offloaded_inputs",
        "closure": {
          "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/start-node/offloaded_outputs",
          "phase": "SUCCEEDED",
          "createdAt": "2024-02-08T02:42:00.736764829Z",
          "updatedAt": "2024-02-08T02:42:00.736896810Z"
        },
        "metadata": {
          "specNodeId": "start-node"
        }
      },
      "outputs": {
        "kickoff_time": "2024-02-08T02:42:00Z"
      }
    },
    {
      "node_exec": {
        "id": {
          "nodeId": "n0",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f7f2026572f57fb57000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/n0/offloaded_inputs",
        "closure": {
          "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/n0/offloaded_outputs",
          "phase": "SUCCEEDED",
          "startedAt": "2024-02-08T02:42:01.429202574Z",
          "duration": "3.909599814s",
          "createdAt": "2024-02-08T02:42:00.963115831Z",
          "updatedAt": "2024-02-08T02:42:05.352768458Z",
          "taskNodeMetadata": {
            "checkpointUri": "s3://union-cloud-oc-staging-dogfood/ok/f7f2026572f57fb57000-n0-0/_flytecheckpoints"
          }
        },
        "metadata": {
          "specNodeId": "n0"
        }
      },
      "task_execs": [
        {
          "id": {
            "taskId": {
              "resourceType": "TASK",
              "project": "flytesnacks",
              "domain": "development",
              "name": "productionizing.lp_schedules.format_date",
              "version": "v0.3.257"
            },
            "nodeExecutionId": {
              "nodeId": "n0",
              "executionId": {
                "project": "flytesnacks",
                "domain": "development",
                "name": "f7f2026572f57fb57000"
              }
            }
          },
          "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/n0/flytesnacks/development/productionizing.lp_schedules.format_date/v0.3.257/0/offloaded_inputs",
          "closure": {
            "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/n0/flytesnacks/development/productionizing.lp_schedules.format_date/v0.3.257/0/offloaded_outputs",
            "phase": "SUCCEEDED",
            "logs": [
              {
                "uri": "https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fopta-oc-staging$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.f7f2026572f57fb57000-n0-0_flytesnacks-development_f7f2026572f57fb57000-n0-0",
                "name": "Cloudwatch Logs (User)"
              },
              {
                "uri": "/console/projects/flytesnacks/domains/development/executions/f7f2026572f57fb57000/nodeId/n0/taskId/productionizing.lp_schedules.format_date/attempt/0/view/logs?duration=all&fromExecutionNav=true",
                "name": "Live Logs (beta) (User)"
              }
            ],
            "startedAt": "2024-02-08T02:42:02Z",
            "duration": "2s",
            "createdAt": "2024-02-08T02:42:01.203711831Z",
            "updatedAt": "2024-02-08T02:42:05.189608874Z",
            "reason": "Started container f7f2026572f57fb57000-n0-0",
            "taskType": "python-task",
            "metadata": {
              "generatedName": "f7f2026572f57fb57000-n0-0",
              "pluginIdentifier": "container"
            },
            "eventVersion": 1,
            "reasons": [
              {
                "occurredAt": "2024-02-08T02:42:01.203711831Z",
                "message": "task submitted to K8s"
              },
              {
                "occurredAt": "2024-02-08T02:42:01Z",
                "message": "[ContainersNotReady|ContainerCreating]: containers with unready status: [f7f2026572f57fb57000-n0-0]|"
              },
              {
                "occurredAt": "2024-02-08T02:42:01Z",
                "message": "Successfully assigned flytesnacks-development/f7f2026572f57fb57000-n0-0 to ip-10-105-7-187.us-east-2.compute.internal"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Successfully pulled image \"ghcr.io/flyteorg/flytecookbook:productionizing-1b49dfdaa870b20ea33f929dccd24c14611b8fd1\" in 269.431289ms (269.449459ms including waiting)"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Created container f7f2026572f57fb57000-n0-0"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Started container f7f2026572f57fb57000-n0-0"
              }
            ]
          }
        }
      ],
      "inputs": {
        "run_date": "2024-02-08T02:42:00Z"
      },
      "outputs": {
        "o0": "2024-02-08 02:42"
      }
    },
    {
      "node_exec": {
        "id": {
          "nodeId": "end-node",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f7f2026572f57fb57000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f7f2026572f57fb57000/end-node/offloaded_inputs",
        "closure": {
          "phase": "SUCCEEDED",
          "createdAt": "2024-02-08T02:42:05.639334403Z",
          "updatedAt": "2024-02-08T02:42:05.894166988Z"
        },
        "metadata": {
          "specNodeId": "end-node"
        }
      }
    }
  ]
}
{
  "Execution": {
    "id": {
      "project": "flytesnacks",
      "domain": "development",
      "name": "f97b4b9a3ee6fc734000"
    },
    "spec": {
      "launch_plan": {
        "resource_type": 3,
        "project": "flytesnacks",
        "domain": "development",
        "name": "my_cron_scheduled_lp",
        "version": "v0.3.248"
      },
      "metadata": {
        "mode": 1,
        "principal": "dogfood-flyteadmin",
        "scheduled_at": {
          "seconds": 1707360120
        },
        "system_metadata": {
          "execution_cluster": "oc-staging",
          "namespace": "flytesnacks-development"
        }
      },
      "NotificationOverrides": null,
      "security_context": {
        "run_as": {}
      }
    },
    "closure": {
      "OutputResult": {
        "Outputs": {
          "Data": {
            "Uri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/offloaded_outputs"
          }
        }
      },
      "phase": 4,
      "started_at": {
        "seconds": 1707360120,
        "nanos": 720573876
      },
      "duration": {
        "seconds": 6,
        "nanos": 509284596
      },
      "created_at": {
        "seconds": 1707360120,
        "nanos": 230757394
      },
      "updated_at": {
        "seconds": 1707360127,
        "nanos": 229857596
      },
      "workflow_id": {
        "resource_type": 2,
        "project": "flytesnacks",
        "domain": "development",
        "name": "productionizing.lp_schedules.date_formatter_wf",
        "version": "v0.3.248"
      },
      "state_change_details": {
        "occurred_at": {
          "seconds": 1707360120,
          "nanos": 230757394
        },
        "principal": "dogfood-flyteadmin"
      }
    }
  },
  "Details": [
    {
      "node_exec": {
        "id": {
          "nodeId": "start-node",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f97b4b9a3ee6fc734000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/start-node/offloaded_inputs",
        "closure": {
          "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/start-node/offloaded_outputs",
          "phase": "SUCCEEDED",
          "createdAt": "2024-02-08T02:42:00.791541718Z",
          "updatedAt": "2024-02-08T02:42:00.791685988Z"
        },
        "metadata": {
          "specNodeId": "start-node"
        }
      },
      "outputs": {
        "kickoff_time": "2024-02-08T02:42:00Z"
      }
    },
    {
      "node_exec": {
        "id": {
          "nodeId": "n0",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f97b4b9a3ee6fc734000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/n0/offloaded_inputs",
        "closure": {
          "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/n0/offloaded_outputs",
          "phase": "SUCCEEDED",
          "startedAt": "2024-02-08T02:42:01.537521612Z",
          "duration": "4.835698428s",
          "createdAt": "2024-02-08T02:42:01.018654536Z",
          "updatedAt": "2024-02-08T02:42:06.385690130Z",
          "taskNodeMetadata": {
            "checkpointUri": "s3://union-cloud-oc-staging-dogfood/w7/f97b4b9a3ee6fc734000-n0-0/_flytecheckpoints"
          }
        },
        "metadata": {
          "specNodeId": "n0"
        }
      },
      "task_execs": [
        {
          "id": {
            "taskId": {
              "resourceType": "TASK",
              "project": "flytesnacks",
              "domain": "development",
              "name": "productionizing.lp_schedules.format_date",
              "version": "v0.3.248"
            },
            "nodeExecutionId": {
              "nodeId": "n0",
              "executionId": {
                "project": "flytesnacks",
                "domain": "development",
                "name": "f97b4b9a3ee6fc734000"
              }
            }
          },
          "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/n0/flytesnacks/development/productionizing.lp_schedules.format_date/v0.3.248/0/offloaded_inputs",
          "closure": {
            "outputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/n0/flytesnacks/development/productionizing.lp_schedules.format_date/v0.3.248/0/offloaded_outputs",
            "phase": "SUCCEEDED",
            "logs": [
              {
                "uri": "https://us-east-2.console.aws.amazon.com/cloudwatch/home?region=us-east-2#logsV2:log-groups/log-group/$252Faws$252Fcontainerinsights$252Fopta-oc-staging$252Fapplication$3FlogStreamNameFilter$3Dvar.log.containers.f97b4b9a3ee6fc734000-n0-0_flytesnacks-development_f97b4b9a3ee6fc734000-n0-0",
                "name": "Cloudwatch Logs (User)"
              },
              {
                "uri": "/console/projects/flytesnacks/domains/development/executions/f97b4b9a3ee6fc734000/nodeId/n0/taskId/productionizing.lp_schedules.format_date/attempt/0/view/logs?duration=all&fromExecutionNav=true",
                "name": "Live Logs (beta) (User)"
              }
            ],
            "startedAt": "2024-02-08T02:42:02Z",
            "duration": "3s",
            "createdAt": "2024-02-08T02:42:01.280622339Z",
            "updatedAt": "2024-02-08T02:42:06.193052073Z",
            "reason": "Started container f97b4b9a3ee6fc734000-n0-0",
            "taskType": "python-task",
            "metadata": {
              "generatedName": "f97b4b9a3ee6fc734000-n0-0",
              "pluginIdentifier": "container"
            },
            "eventVersion": 1,
            "reasons": [
              {
                "occurredAt": "2024-02-08T02:42:01.280622339Z",
                "message": "task submitted to K8s"
              },
              {
                "occurredAt": "2024-02-08T02:42:01Z",
                "message": "[ContainersNotReady|ContainerCreating]: containers with unready status: [f97b4b9a3ee6fc734000-n0-0]|"
              },
              {
                "occurredAt": "2024-02-08T02:42:01Z",
                "message": "Successfully assigned flytesnacks-development/f97b4b9a3ee6fc734000-n0-0 to ip-10-105-4-57.us-east-2.compute.internal"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Successfully pulled image \"ghcr.io/flyteorg/flytecookbook:productionizing-58a6cb40fb0d26804b031c5bbd4bd07c2de73bb4\" in 248.895368ms (248.907618ms including waiting)"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Created container f97b4b9a3ee6fc734000-n0-0"
              },
              {
                "occurredAt": "2024-02-08T02:42:02Z",
                "message": "Started container f97b4b9a3ee6fc734000-n0-0"
              }
            ]
          }
        }
      ],
      "inputs": {
        "run_date": "2024-02-08T02:42:00Z"
      },
      "outputs": {
        "o0": "2024-02-08 02:42"
      }
    },
    {
      "node_exec": {
        "id": {
          "nodeId": "end-node",
          "executionId": {
            "project": "flytesnacks",
            "domain": "development",
            "name": "f97b4b9a3ee6fc734000"
          }
        },
        "inputUri": "s3://union-staging-tenant-dogfood/metadata/flytesnacks/development/f97b4b9a3ee6fc734000/end-node/offloaded_inputs",
        "closure": {
          "phase": "SUCCEEDED",
          "createdAt": "2024-02-08T02:42:06.718823685Z",
          "updatedAt": "2024-02-08T02:42:06.948742227Z"
        },
        "metadata": {
          "specNodeId": "end-node"
        }
      }
    }
  ]
}

```

## Type
- [ ] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
_How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
