### PR TITLE
Fix: Check for git authentication when GITHUB_TOKEN exists

### DIFF
--- a/pkg/github/githubutil.go
+++ b/pkg/github/githubutil.go
@@ -232,6 +232,7 @@ func GetGHRepoService() GHRepoService {
 				&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 			)))
 			if _, err := ListReleases(flyte, gh.Repositories); err != nil {
+				logger.Warnf(context.Background(), "GITHUB_TOKEN exists failed to fetch releases, using empty http.Client: %s.", err)
 				gh = nil
 			}
 		}

--- a/pkg/github/githubutil.go
+++ b/pkg/github/githubutil.go
@@ -232,7 +232,7 @@ func GetGHRepoService() GHRepoService {
 				&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 			)))
 			if _, err := ListReleases(flyte, gh.Repositories); err != nil {
-				logger.Warnf(context.Background(), "GITHUB_TOKEN exists failed to fetch releases, using empty http.Client: %s.", err)
+				logger.Warnf(context.Background(), "Found GITHUB_TOKEN but failed to fetch releases. Using empty http.Client: %s.", err)
 				gh = nil
 			}
 		}

--- a/pkg/github/githubutil.go
+++ b/pkg/github/githubutil.go
@@ -231,7 +231,11 @@ func GetGHRepoService() GHRepoService {
 			gh = github.NewClient(oauth2.NewClient(context.Background(), oauth2.StaticTokenSource(
 				&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
 			)))
-		} else {
+			if _, err := ListReleases(flyte, gh.Repositories); err != nil {
+				gh = nil
+			}
+		}
+		if gh == nil {
 			gh = github.NewClient(&http.Client{})
 		}
 		return gh.Repositories


### PR DESCRIPTION
# TL;DR
When flytectl demo start is ran with `GITHUB_TOKEN`, it throws 401 error. Setting `GITHUB_TOKEN` empty works.
https://github.com/flyteorg/flyte/issues/4879

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [x] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
* Validating GITHUB client before creating gh

## Tracking Issue
[https://github.com/flyteorg/flyte/issues/<number>](https://github.com/flyteorg/flyte/issues/4879)

## Follow-up issue
