### PR TITLE
use sphinx-design directives instead of sphinx-panels

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,29 +21,31 @@ Installation
 
 Flytectl is a Golang binary that can be installed on any platform supported by Golang.
 
-.. tabbed:: OSX
+.. tab-set::
 
-  .. prompt:: bash $
+    .. tab-item:: OSX
 
-      brew install flyteorg/homebrew-tap/flytectl
+      .. prompt:: bash $
 
-  *Upgrade* existing installation using the following command:
+          brew install flyteorg/homebrew-tap/flytectl
 
-  .. prompt:: bash $
+      *Upgrade* existing installation using the following command:
 
-      flytectl upgrade
+      .. prompt:: bash $
 
-.. tabbed:: Other Operating systems
+          flytectl upgrade
 
-  .. prompt:: bash $
+    .. tab-item:: Other Operating systems
 
-      curl -sL https://ctl.flyte.org/install | bash
+      .. prompt:: bash $
 
-  *Upgrade* existing installation using the following command:
+          curl -sL https://ctl.flyte.org/install | bash
 
-  .. prompt:: bash $
+      *Upgrade* existing installation using the following command:
 
-      flytectl upgrade
+      .. prompt:: bash $
+
+          flytectl upgrade
 
 **Test** if Flytectl is installed correctly (your Flytectl version should be > 0.2.0) using the following command:
 
@@ -66,50 +68,52 @@ The full list of available configurable options can be found by running ``flytec
 
     Currently, the Project ``-p``, Domain ``-d``, and Output ``-o`` flags cannot be used in the config file.
 
-.. tabbed:: Local Flyte Sandbox
+.. tab-set::
 
-    Automatically configured for you by ``flytectl sandbox`` command.
+    .. tab-item:: Local Flyte Sandbox
 
-    .. code-block:: yaml
+        Automatically configured for you by ``flytectl sandbox`` command.
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///localhost:30081
-          insecure: true # Set to false to enable TLS/SSL connection (not recommended except on local sandbox deployment).
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
+        .. code-block:: yaml
 
-.. tabbed:: AWS Configuration
+            admin:
+              # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+              endpoint: dns:///localhost:30081
+              insecure: true # Set to false to enable TLS/SSL connection (not recommended except on local sandbox deployment).
+              authType: Pkce # authType: Pkce # if using authentication or just drop this.
 
-    .. code-block:: yaml
+    .. tab-item:: AWS Configuration
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///<replace-me>
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
-          insecure: true # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
+        .. code-block:: yaml
 
-.. tabbed:: GCS Configuration
+            admin:
+              # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+              endpoint: dns:///<replace-me>
+              authType: Pkce # authType: Pkce # if using authentication or just drop this.
+              insecure: true # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
 
-    .. code-block:: yaml
+    .. tab-item:: GCS Configuration
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///<replace-me>
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
-          insecure: false # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
+        .. code-block:: yaml
 
-.. tabbed:: Others
+            admin:
+              # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+              endpoint: dns:///<replace-me>
+              authType: Pkce # authType: Pkce # if using authentication or just drop this.
+              insecure: false # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
 
-    For other supported storage backends like Oracle, Azure, etc., refer to the configuration structure `here <https://pkg.go.dev/github.com/flyteorg/flyte/flytestdlib/storage#Config>`__.
+    .. tab-item:: Others
 
-    Place the config file in ``$HOME/.flyte`` directory with the name config.yaml.
-    This file is typically searched in:
+        For other supported storage backends like Oracle, Azure, etc., refer to the configuration structure `here <https://pkg.go.dev/github.com/flyteorg/flyte/flytestdlib/storage#Config>`__.
 
-    * ``$HOME/.flyte``
-    * currDir from where you run flytectl
-    * ``/etc/flyte/config``
-    
-    You can also pass the file name in the command line using ``--config <config-file-path>``.
+        Place the config file in ``$HOME/.flyte`` directory with the name config.yaml.
+        This file is typically searched in:
+
+        * ``$HOME/.flyte``
+        * currDir from where you run flytectl
+        * ``/etc/flyte/config``
+
+        You can also pass the file name in the command line using ``--config <config-file-path>``.
 
 
 .. toctree::

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -14,29 +14,31 @@ Installation
 
 Flytectl is a Golang binary that can be installed on any platform supported by Golang.
 
-.. tabbed:: OSX
+.. tab-set::
 
-  .. prompt:: bash $
+    .. tab-item:: OSX
 
-      brew install flyteorg/homebrew-tap/flytectl
+      .. prompt:: bash $
 
-  *Upgrade* existing installation using the following command:
+          brew install flyteorg/homebrew-tap/flytectl
 
-  .. prompt:: bash $
+      *Upgrade* existing installation using the following command:
 
-      flytectl upgrade
+      .. prompt:: bash $
 
-.. tabbed:: Other Operating systems
+          flytectl upgrade
 
-  .. prompt:: bash $
+    .. tab-item:: Other Operating systems
 
-      curl -sL https://ctl.flyte.org/install | bash
+      .. prompt:: bash $
 
-  *Upgrade* existing installation using the following command:
+          curl -sL https://ctl.flyte.org/install | bash
 
-  .. prompt:: bash $
+      *Upgrade* existing installation using the following command:
 
-      flytectl upgrade
+      .. prompt:: bash $
+
+          flytectl upgrade
 
 **Test** if Flytectl is installed correctly (your Flytectl version should be > 0.2.0) using the following command:
 
@@ -59,47 +61,49 @@ The full list of available configurable options can be found by running ``flytec
 
     Currently, the Project ``-p``, Domain ``-d``, and Output ``-o`` flags cannot be used in the config file.
 
-.. tabbed:: Local Flyte Sandbox
+.. tab-set::
 
-    Automatically configured for you by ``flytectl sandbox`` command.
+    .. tab-item:: Local Flyte Sandbox
 
-    .. code-block:: yaml
+        Automatically configured for you by ``flytectl sandbox`` command.
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///localhost:30081
-          insecure: true # Set to false to enable TLS/SSL connection (not recommended except on local sandbox deployment).
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
+        .. code-block:: yaml
 
-.. tabbed:: AWS Configuration
+            admin:
+            # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+            endpoint: dns:///localhost:30081
+            insecure: true # Set to false to enable TLS/SSL connection (not recommended except on local sandbox deployment).
+            authType: Pkce # authType: Pkce # if using authentication or just drop this.
 
-    .. code-block:: yaml
+    .. tab-item:: AWS Configuration
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///<replace-me>
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
-          insecure: true # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
+        .. code-block:: yaml
 
-.. tabbed:: GCS Configuration
+            admin:
+            # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+            endpoint: dns:///<replace-me>
+            authType: Pkce # authType: Pkce # if using authentication or just drop this.
+            insecure: true # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
 
-    .. code-block:: yaml
+    .. tab-item:: GCS Configuration
 
-        admin:
-          # For GRPC endpoints you might want to use dns:///flyte.myexample.com
-          endpoint: dns:///<replace-me>
-          authType: Pkce # authType: Pkce # if using authentication or just drop this.
-          insecure: false # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
+        .. code-block:: yaml
 
-.. tabbed:: Others
+            admin:
+            # For GRPC endpoints you might want to use dns:///flyte.myexample.com
+            endpoint: dns:///<replace-me>
+            authType: Pkce # authType: Pkce # if using authentication or just drop this.
+            insecure: false # insecure: True # Set to true if the endpoint isn't accessible through TLS/SSL connection (not recommended except on local sandbox deployment)
 
-    For other supported storage backends like Oracle, Azure, etc., refer to the configuration structure `here <https://pkg.go.dev/github.com/flyteorg/flyte/flytestdlib/storage#Config>`__.
+    .. tab-item:: Others
 
-    Place the config file in ``$HOME/.flyte`` directory with the name config.yaml.
-    This file is typically searched in:
+        For other supported storage backends like Oracle, Azure, etc., refer to the configuration structure `here <https://pkg.go.dev/github.com/flyteorg/flyte/flytestdlib/storage#Config>`__.
 
-    * ``$HOME/.flyte``
-    * currDir from where you run flytectl
-    * ``/etc/flyte/config``
-    
-    You can also pass the file name in the command line using ``--config <config-file-path>``.
+        Place the config file in ``$HOME/.flyte`` directory with the name config.yaml.
+        This file is typically searched in:
+
+        * ``$HOME/.flyte``
+        * currDir from where you run flytectl
+        * ``/etc/flyte/config``
+
+        You can also pass the file name in the command line using ``--config <config-file-path>``.


### PR DESCRIPTION
## Why are the changes needed?

We are currently using [sphinx-panels](https://sphinx-panels.readthedocs.io/en/latest/) for various documentation elements like dropdowns and tabs. However, `sphinx-panels` is no longer maintained and is restricting the version of sphinx we use to `4.5.0`. The up-to-date solution for this is [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/).

NOTE: We'll have to merge the related PRs in the following order:
1. https://github.com/flyteorg/flytekit/pull/2364, https://github.com/flyteorg/flytesnacks/pull/1652, https://github.com/flyteorg/flytectl/pull/471
2. https://github.com/flyteorg/flyte/pull/5254

## What changes were proposed in this pull request?

This PR makes changes to the docs to use `sphinx-design` directives

<img width="1250" alt="image" src="https://github.com/flyteorg/flyte/assets/2816689/81e88999-64c7-4e6c-af95-31d676ceb16f">


## How was this patch tested?

Build the docs locally:

Make sure you have the `sphinx-design` branch checked out in the `flytekit`, `flytesnacks`, and `flytectl` repo. Then build the docs in the `flyte` repo like so:

```
FLYTEKIT_LOCAL_PATH=~/git/flytekit FLYTESNACKS_LOCAL_PATH=~/git/flytesnacks FLYTECTL_LOCAL_PATH=~/git/flytectl make docs
```
