### PR TITLE
Prefetch data while running Bubbletea pagination

### DIFF
--- a/cmd/get/execution.go
+++ b/cmd/get/execution.go
@@ -154,17 +154,15 @@ func getExecutionFunc(ctx context.Context, args []string, cmdCtx cmdCore.Command
 		return adminPrinter.Print(config.GetConfig().MustOutputFormat(), executionColumns,
 			ExecutionToProtoMessages(executions)...)
 	}
+	if config.GetConfig().Interactive {
+		err := bubbletea.Paginator(executionColumns, getCallBack(ctx, cmdCtx), execution.DefaultConfig.Filter)
+		return err
+	}
 	executionList, err := cmdCtx.AdminFetcherExt().ListExecution(ctx, config.GetConfig().Project, config.GetConfig().Domain, execution.DefaultConfig.Filter)
 	if err != nil {
 		return err
 	}
 	logger.Infof(ctx, "Retrieved %v executions", len(executionList.Executions))
-
-	if config.GetConfig().Interactive {
-		bubbletea.Paginator(executionColumns, getCallBack(ctx, cmdCtx))
-		return nil
-	}
-
 	return adminPrinter.Print(config.GetConfig().MustOutputFormat(), executionColumns,
 		ExecutionToProtoMessages(executionList.Executions)...)
 }

--- a/pkg/bubbletea/bubbletea_pagination.go
+++ b/pkg/bubbletea/bubbletea_pagination.go
@@ -4,17 +4,29 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/paginator"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/flyteorg/flytectl/pkg/printer"
 	"github.com/golang/protobuf/proto"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+var (
+	spin            = false
+	fetchingBack    = false
+	fetchingForward = false
+	mutex           sync.Mutex
+)
+
 type pageModel struct {
-	items     []proto.Message
+	items     *[]proto.Message
 	paginator paginator.Model
+	spinner   spinner.Model
 }
 
 func newModel(initMsg []proto.Message) pageModel {
@@ -22,14 +34,19 @@ func newModel(initMsg []proto.Message) pageModel {
 	p.PerPage = msgPerPage
 	p.SetTotalPages(len(initMsg))
 
+	s := spinner.New()
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("56"))
+	s.Spinner = spinner.Points
+
 	return pageModel{
 		paginator: p,
-		items:     initMsg,
+		spinner:   s,
+		items:     &initMsg,
 	}
 }
 
 func (m pageModel) Init() tea.Cmd {
-	return nil
+	return m.spinner.Tick
 }
 
 func (m pageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -40,21 +57,134 @@ func (m pageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "esc", "ctrl+c":
 			return m, tea.Quit
 		}
+		// TODO 來回toggle太快會壞掉記得測！
+		switch {
+		case key.Matches(msg, m.paginator.KeyMap.NextPage):
+			// If already tried to fetch data and there is no more data to fetch, don't fetch again (won't show spinner)
+			value, ok := batchLen[lastBatchIndex+1]
+			if !ok || value != 0 {
+				if m.paginator.Page == (lastBatchIndex+1)*pagePerBatch-prefetchThreshold && !fetchingForward {
+					// if fetchingBack {
+					// 	mutex.Lock()
+					// }
+					fetchingForward = true
+					cmd = fetchDataCmd(lastBatchIndex+1, forward)
+				}
+			}
+		case key.Matches(msg, m.paginator.KeyMap.PrevPage):
+			if m.paginator.Page-firstBatchIndex*pagePerBatch == 0 {
+				return m, cmd
+			}
+			if (m.paginator.Page == firstBatchIndex*pagePerBatch+prefetchThreshold) && (firstBatchIndex > 0) && !fetchingBack {
+				// if fetchingForward {
+				// 	mutex.Lock()
+				// }
+				fetchingBack = true
+				cmd = fetchDataCmd(firstBatchIndex-1, back)
+			}
+		}
+
+	// case spinner.TickMsg:
+	// 	m.spinner, cmd = m.spinner.Update(msg)
+	// 	return m, cmd
+	case dataMsg:
+		if len(msg.newItems) != 0 {
+			if msg.fetchDirection == forward {
+				*m.items = append(*m.items, msg.newItems...)
+				lastBatchIndex++
+				if lastBatchIndex-firstBatchIndex >= localBatchLimit {
+					// fmt.Println("delete back")
+					*m.items = (*m.items)[batchLen[firstBatchIndex]:]
+					//fmt.Println(len(*m.items), firstBatchIndex, batchLen[firstBatchIndex], "after forward")
+					//localPageIndex -= batchLen[firstBatchIndex] / msgPerPage
+					firstBatchIndex++
+
+				}
+				fetchingForward = false
+			} else {
+				*m.items = append(msg.newItems, *m.items...)
+				firstBatchIndex--
+				if lastBatchIndex-firstBatchIndex >= localBatchLimit {
+					// fmt.Println("delete forward")
+					*m.items = (*m.items)[:len(*m.items)-batchLen[lastBatchIndex]]
+					// batchLen[lastBatchIndex] = 0
+					lastBatchIndex--
+				}
+				fetchingBack = false
+			}
+			m.paginator.SetTotalPages(countTotalPages())
+		}
+		m.paginator.Page = _min(_max(m.paginator.Page, firstBatchIndex*pagePerBatch), (lastBatchIndex+1)*pagePerBatch-1)
+		// localPageIndex = _max(m.paginator.Page-firstBatchIndex*pagePerBatch, 0)
+		return m, nil
 	}
-	m.paginator, cmd = m.paginator.Update(msg)
-	preFetchBatch(&m)
+	//fmt.Println(len(*m.items))
+
+	// switch msg := msg.(type) {
+	// case tea.KeyMsg:
+	// 	switch {
+	// 	case key.Matches(msg, m.paginator.KeyMap.PrevPage):
+	// 		if localPageIndex == 0 {
+	// 			return m, cmd
+	// 		}
+	// 	}
+	// }
+
+	// fmt.Println("before ", m.paginator.Page-firstBatchIndex*pagePerBatch, firstBatchIndex, lastBatchIndex)
+	// fmt.Printf("before %v %d %d %d\n", batchLen, m.paginator.TotalPages, len(*m.items), m.paginator.Page)
+
+	// switch msg := msg.(type) {
+
+	m.paginator, _ = m.paginator.Update(msg)
+
+	// fmt.Println("after ", m.paginator.Page, firstBatchIndex, lastBatchIndex)
+	// fmt.Printf("after %v %d %d %d\n", batchLen, m.paginator.TotalPages, len(*m.items), m.paginator.Page)
+
 	return m, cmd
+}
+
+type fetchDirection int
+
+const (
+	forward fetchDirection = iota
+	back
+)
+
+type dataMsg struct {
+	newItems       []proto.Message
+	batchIndex     int
+	fetchDirection fetchDirection
+}
+
+func fetchDataCmd(batchIndex int, fetchDirection fetchDirection) tea.Cmd {
+	// fmt.Println("fetching")
+	spin = true
+	return func() tea.Msg {
+
+		msg := dataMsg{
+			newItems:       getMessageList(batchIndex),
+			batchIndex:     batchIndex,
+			fetchDirection: fetchDirection,
+		}
+		// mutex.Unlock()
+		spin = false
+		return msg
+	}
 }
 
 func (m pageModel) View() string {
 	var b strings.Builder
 	table, err := getTable(&m)
 	if err != nil {
-		return ""
+		return "Error rendering table"
 	}
 	b.WriteString(table)
-	b.WriteString(fmt.Sprintf("  PAGE - %d\n", m.paginator.Page+1))
+	b.WriteString(fmt.Sprintf("  PAGE - %d   ", m.paginator.Page+1))
+	if spin {
+		b.WriteString(fmt.Sprintf("%s%s", m.spinner.View(), " Loading new pages..."))
+	}
 	b.WriteString("\n\n  h/l ←/→ page • q: quit\n")
+
 	return b.String()
 }
 
@@ -64,7 +194,9 @@ func Paginator(_listHeader []printer.Column, _callback DataCallback) {
 
 	var msg []proto.Message
 	for i := firstBatchIndex; i < lastBatchIndex+1; i++ {
-		msg = append(msg, getMessageList(i)...)
+		newMessages := getMessageList(i)
+		msg = append(msg, newMessages...)
+		// batchLen[i] = len(newMessages)
 	}
 
 	p := tea.NewProgram(newModel(msg))

--- a/pkg/bubbletea/bubbletea_pagination.go
+++ b/pkg/bubbletea/bubbletea_pagination.go
@@ -129,7 +129,7 @@ func (m pageModel) View() string {
 	return b.String()
 }
 
-func Paginator(_listHeader []printer.Column, _callback dataCallback) {
+func Paginator(_listHeader []printer.Column, _callback DataCallback) {
 	listHeader = _listHeader
 	callback = _callback
 

--- a/pkg/bubbletea/bubbletea_pagination.go
+++ b/pkg/bubbletea/bubbletea_pagination.go
@@ -89,8 +89,9 @@ func (m pageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// 	m.spinner, cmd = m.spinner.Update(msg)
 	// 	return m, cmd
 	case dataMsg:
-		if len(msg.newItems) != 0 {
-			if msg.fetchDirection == forward {
+		// TODO: Handle error
+		if msg.fetchDirection == forward {
+			if len(msg.newItems) != 0 {
 				if m.paginator.Page/pagePerBatch >= lastBatchIndex {
 					*m.items = append(*m.items, msg.newItems...)
 					lastBatchIndex++
@@ -102,8 +103,10 @@ func (m pageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						firstBatchIndex++
 					}
 				}
-				fetchingForward = false
-			} else if msg.fetchDirection == backward {
+			}
+			fetchingForward = false
+		} else if msg.fetchDirection == backward {
+			if len(msg.newItems) != 0 {
 				if m.paginator.Page/pagePerBatch <= firstBatchIndex {
 					*m.items = append(msg.newItems, *m.items...)
 					firstBatchIndex--
@@ -114,10 +117,11 @@ func (m pageModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						lastBatchIndex--
 					}
 				}
-				fetchingBackward = false
+
 			}
-			m.paginator.SetTotalPages(countTotalPages())
+			fetchingBackward = false
 		}
+		m.paginator.SetTotalPages(countTotalPages())
 		m.paginator.Page = _min(_max(m.paginator.Page, firstBatchIndex*pagePerBatch), (lastBatchIndex+1)*pagePerBatch-1)
 		// localPageIndex = _max(m.paginator.Page-firstBatchIndex*pagePerBatch, 0)
 		return m, nil

--- a/pkg/bubbletea/bubbletea_pagination_util.go
+++ b/pkg/bubbletea/bubbletea_pagination_util.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/flyteorg/flytectl/pkg/filters"
@@ -25,7 +24,7 @@ const (
 	msgPerPage        = 10
 	pagePerBatch      = msgPerBatch / msgPerPage
 	prefetchThreshold = pagePerBatch - 1
-	localBatchLimit   = 2 // Please set localBatchLimit at least 2
+	localBatchLimit   = 10 // Please set localBatchLimit at least 2
 )
 
 var (
@@ -100,7 +99,7 @@ func getMessageList(batchIndex int) []proto.Message {
 		spin = false
 		mutex.Unlock()
 	}()
-	time.Sleep(2 * time.Second)
+
 	msg := callback(filters.Filters{
 		Limit:  msgPerBatch,
 		Page:   int32(batchIndex + 1),
@@ -137,7 +136,7 @@ func fetchDataCmd(batchIndex int, fetchDirection direction) tea.Cmd {
 	}
 }
 
-func countTotalPages() int {
+func getLocalLastPage() int {
 	sum := 0
 	for i := 0; i < lastBatchIndex+1; i++ {
 		length, ok := batchLen[i]

--- a/pkg/bubbletea/bubbletea_pagination_util.go
+++ b/pkg/bubbletea/bubbletea_pagination_util.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-type dataCallback func(filter filters.Filters) []proto.Message
+type DataCallback func(filter filters.Filters) []proto.Message
 
 type printTableProto struct{ proto.Message }
 
@@ -33,7 +33,7 @@ var (
 	lastBatchIndex  = 0
 	batchLen        = make(map[int]int)
 	// Callback function used to fetch data from the module that called bubbletea pagination.
-	callback dataCallback
+	callback DataCallback
 	// The header of the table
 	listHeader []printer.Column
 	// Avoid fetching back and forward at the same time

--- a/pkg/bubbletea/bubbletea_pagination_util.go
+++ b/pkg/bubbletea/bubbletea_pagination_util.go
@@ -92,8 +92,14 @@ func getTable(m *pageModel) (string, error) {
 }
 
 func getMessageList(batchIndex int) []proto.Message {
+
 	mutex.Lock()
-	defer mutex.Unlock()
+	spin = true
+	defer func() {
+		spin = false
+		mutex.Unlock()
+	}()
+
 	time.Sleep(2 * time.Second)
 	msg := callback(filters.Filters{
 		Limit:  msgPerBatch,

--- a/pkg/bubbletea/bubbletea_pagination_util.go
+++ b/pkg/bubbletea/bubbletea_pagination_util.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/flyteorg/flytectl/pkg/filters"
@@ -24,7 +25,7 @@ const (
 	msgPerPage        = 10
 	pagePerBatch      = msgPerBatch / msgPerPage
 	prefetchThreshold = pagePerBatch - 1
-	localBatchLimit   = 10 // Please set localBatchLimit at least 2
+	localBatchLimit   = 2 // Please set localBatchLimit at least 2
 )
 
 var (
@@ -99,7 +100,7 @@ func getMessageList(batchIndex int) []proto.Message {
 		spin = false
 		mutex.Unlock()
 	}()
-
+	time.Sleep(2 * time.Second)
 	msg := callback(filters.Filters{
 		Limit:  msgPerBatch,
 		Page:   int32(batchIndex + 1),
@@ -112,18 +113,20 @@ func getMessageList(batchIndex int) []proto.Message {
 	return msg
 }
 
+type direction int
+
 const (
-	forward int = iota
+	forward direction = iota
 	backward
 )
 
 type newDataMsg struct {
 	newItems       []proto.Message
 	batchIndex     int
-	fetchDirection int
+	fetchDirection direction
 }
 
-func fetchDataCmd(batchIndex int, fetchDirection int) tea.Cmd {
+func fetchDataCmd(batchIndex int, fetchDirection direction) tea.Cmd {
 	return func() tea.Msg {
 		msg := newDataMsg{
 			newItems:       getMessageList(batchIndex),


### PR DESCRIPTION
# TL;DR
The get function takes more time to fetch data from the remote server as the amount increases, hence we only fetch 100 rows initially, and prefetch 100 rows of data at once while the user scrolls through pages to enhance the user experience. 


## Type
- [ ] Bug Fix
- [X] Feature
- [ ] Plugin

## Are all requirements met?

- [X] Code completed
- [X] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
For testing run:
```bash
make compile
./bin/flytectl get execution -p my-project -d development -i
```

We initially fetch the first 100 rows when the paginator is called and start to prefetch the next batch (next 100 rows).
Prefetch will be triggered when the current page exceeds a prefetch threshold.
The first or last batch will be discarded when it exceeds the cache limit (currently set to 1000 rows).
We added a loading animation to indicate the fetching process is ongoing.
![Apr-27-2024 17-32-22](https://github.com/flyteorg/flytectl/assets/50983601/f59203a1-c7ed-4610-9d43-1cc5ef605346)

Users can use --filter.page flag to specify their starting page, if not specified, page will start from 1.
![Apr-28-2024 16-21-42](https://github.com/flyteorg/flytectl/assets/50983601/313653a9-3464-4c4a-89a4-cb9e7897b2f1)

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4440


## Follow-up issue
Follow-up of https://github.com/flyteorg/flytectl/pull/473

Big thanks to @troychiu for discussing and debugging with me!! :raised_hands: :heart:
