### PR TITLE
Do not upload codecoverage data from boilerplate

### DIFF
--- a/boilerplate/flyte/golang_test_targets/Makefile
+++ b/boilerplate/flyte/golang_test_targets/Makefile
@@ -54,4 +54,3 @@ test_unit_visual:
 .PHONY: test_unit_codecov
 test_unit_codecov:
 	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
-	curl -s https://codecov.io/bash > codecov_bash.sh && bash codecov_bash.sh


### PR DESCRIPTION
# TL;DR
Fix Codecov uploads blocking errors

## Type
- [x] Bug Fix
- [ ] Feature
- [ ] Plugin

## Are all requirements met?

- [ ] Code completed
- [ ] Smoke tested
- [ ] Unit tests added
- [ ] Code documentation added
- [ ] Any pending items have an associated Issue

## Complete description
Similar to https://github.com/flyteorg/flyte/pull/5298, let's not use codecov's script to upload code coverage data.

## Tracking Issue
NA

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
